### PR TITLE
fix: page load performance improvements

### DIFF
--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getScheduleData, getFormResponses } from "@/lib/schedule-utils";
 import { sportsConfig } from "@/lib/sports-config";
-import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/user";
 import SportPage from "@/components/sport-page";
 
 export const dynamic = "force-dynamic";
@@ -21,19 +21,14 @@ export default async function SportRoute({
   const formResponses =
     isFormOpen && scheduleData?.response_sheet_id && config.responseTable
       ? await getFormResponses(
-          scheduleData.response_sheet_id,
-          config.responseTable.sheetTab,
-          config.responseTable.columns,
-        )
+        scheduleData.response_sheet_id,
+        config.responseTable.sheetTab,
+        config.responseTable.columns,
+      )
       : [];
 
-  let user = null;
-  if (config.authEnabled) {
-    const supabase = await createClient();
-    // Middleware already validated the JWT; getSession() reads it locally (no network call)
-    const { data } = await supabase.auth.getSession();
-    user = data.session?.user ?? null;
-  }
+  // Middleware validates the JWT and forwards the user via request header.
+  const user = config.authEnabled ? await getUser() : null;
 
   return (
     <SportPage

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -30,8 +30,9 @@ export default async function SportRoute({
   let user = null;
   if (config.authEnabled) {
     const supabase = await createClient();
-    const { data } = await supabase.auth.getUser();
-    user = data.user;
+    // Middleware already validated the JWT; getSession() reads it locally (no network call)
+    const { data } = await supabase.auth.getSession();
+    user = data.session?.user ?? null;
   }
 
   return (

--- a/app/softball/admin/page.tsx
+++ b/app/softball/admin/page.tsx
@@ -151,9 +151,11 @@ export default async function AdminPage({
 }) {
   const { tab = "upcoming" } = await searchParams;
   const supabase = await createClient();
+  // Middleware already validated the JWT; getSession() reads it locally (no network call)
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
+  const user = session?.user;
 
   if (!user) redirect(`/${SPORT}`);
 

--- a/app/softball/admin/page.tsx
+++ b/app/softball/admin/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/user";
 import { Badge } from "@/components/ui/badge";
 import {
   Accordion,
@@ -151,11 +152,8 @@ export default async function AdminPage({
 }) {
   const { tab = "upcoming" } = await searchParams;
   const supabase = await createClient();
-  // Middleware already validated the JWT; getSession() reads it locally (no network call)
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const user = session?.user;
+  // Middleware validates the JWT and forwards the user via request header.
+  const user = await getUser();
 
   if (!user) redirect(`/${SPORT}`);
 

--- a/app/softball/page.tsx
+++ b/app/softball/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/user";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Settings } from "lucide-react";
 import AuthButton from "@/components/sports/auth-button";
@@ -19,10 +20,8 @@ export default async function SoftballPage() {
   const supabase = await createClient();
 
   // ── Auth ───────────────────────────────────────────────────────
-  // Middleware already validated the JWT; getSession() reads it locally (no network call)
-  const user = config.authEnabled
-    ? (await supabase.auth.getSession()).data.session?.user ?? null
-    : null;
+  // Middleware validates the JWT and forwards the user via request header.
+  const user = config.authEnabled ? await getUser() : null;
 
   // ── Roles & access ─────────────────────────────────────────────
   let isAdmin = false;

--- a/app/softball/page.tsx
+++ b/app/softball/page.tsx
@@ -19,8 +19,9 @@ export default async function SoftballPage() {
   const supabase = await createClient();
 
   // ── Auth ───────────────────────────────────────────────────────
+  // Middleware already validated the JWT; getSession() reads it locally (no network call)
   const user = config.authEnabled
-    ? (await supabase.auth.getUser()).data.user
+    ? (await supabase.auth.getSession()).data.session?.user ?? null
     : null;
 
   // ── Roles & access ─────────────────────────────────────────────

--- a/app/softball/session/[id]/page.tsx
+++ b/app/softball/session/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { getUser } from "@/lib/supabase/user";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -52,12 +53,8 @@ export default async function SessionDetailPage({
   const supabase = await createClient();
   const sportConfig = sportsConfig["softball"];
 
-  let user = null;
-  if (sportConfig?.authEnabled) {
-    // Middleware already validated the JWT; getSession() reads it locally (no network call)
-    const { data } = await supabase.auth.getSession();
-    user = data.session?.user ?? null;
-  }
+  // Middleware validates the JWT and forwards the user via request header.
+  const user = sportConfig?.authEnabled ? await getUser() : null;
 
   const { data: session } = await supabase
     .from("sessions")

--- a/app/softball/session/[id]/page.tsx
+++ b/app/softball/session/[id]/page.tsx
@@ -64,52 +64,52 @@ export default async function SessionDetailPage({
 
   if (!session) notFound();
 
-  let isAdmin = false;
-  let isTeamMember = !sportConfig?.restrictedAccessEnabled;
-  let userSignupStatus: SignupStatus | null = null;
-
-  if (user) {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .single();
-
-    isAdmin = profile?.role === "admin";
-
-    if (!isAdmin) {
-      const { data: sportRole } = await supabase
-        .from("sport_roles")
-        .select("role, is_team_member")
-        .eq("user_id", user.id)
-        .eq("sport", session.sport)
-        .single();
-
-      isAdmin = sportRole?.role === "admin";
-      isTeamMember = sportConfig?.restrictedAccessEnabled
-        ? sportRole?.is_team_member || isAdmin
-        : true;
-    } else {
-      isTeamMember = true;
-    }
-
-    const { data: signup } = await supabase
-      .from("signups")
-      .select("status")
-      .eq("session_id", id)
-      .eq("user_id", user.id)
-      .neq("status", "cancelled")
-      .single();
-
-    userSignupStatus = (signup?.status as SignupStatus) ?? null;
-  }
-
-  const { data: signups } = await supabase
+  // Run user-role queries and the public signups query in parallel
+  const signupsPromise = supabase
     .from("signups")
     .select("*, profiles(full_name, email)")
     .eq("session_id", id)
     .neq("status", "cancelled")
     .order("created_at", { ascending: true });
+
+  let isAdmin = false;
+  let isTeamMember = !sportConfig?.restrictedAccessEnabled;
+  let userSignupStatus: SignupStatus | null = null;
+
+  if (user) {
+    const [profileResult, sportRoleResult, userSignupResult] =
+      await Promise.all([
+        supabase
+          .from("profiles")
+          .select("role")
+          .eq("id", user.id)
+          .single(),
+        supabase
+          .from("sport_roles")
+          .select("role, is_team_member")
+          .eq("user_id", user.id)
+          .eq("sport", session.sport)
+          .single(),
+        supabase
+          .from("signups")
+          .select("status")
+          .eq("session_id", id)
+          .eq("user_id", user.id)
+          .neq("status", "cancelled")
+          .single(),
+      ]);
+
+    isAdmin =
+      profileResult.data?.role === "admin" ||
+      sportRoleResult.data?.role === "admin";
+    isTeamMember = sportConfig?.restrictedAccessEnabled
+      ? isAdmin || !!sportRoleResult.data?.is_team_member
+      : true;
+    userSignupStatus =
+      (userSignupResult.data?.status as SignupStatus) ?? null;
+  }
+
+  const { data: signups } = await signupsPromise;
 
   const allSignups = signups ?? [];
   const confirmedSignups = allSignups.filter((s) => s.status === "confirmed");

--- a/app/softball/session/[id]/page.tsx
+++ b/app/softball/session/[id]/page.tsx
@@ -54,8 +54,9 @@ export default async function SessionDetailPage({
 
   let user = null;
   if (sportConfig?.authEnabled) {
-    const { data } = await supabase.auth.getUser();
-    user = data.user;
+    // Middleware already validated the JWT; getSession() reads it locally (no network call)
+    const { data } = await supabase.auth.getSession();
+    user = data.session?.user ?? null;
   }
 
   const { data: session } = await supabase

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -26,7 +26,25 @@ export async function updateSession(request: NextRequest) {
   );
 
   // Refresh the session — this is the critical call that keeps tokens alive
-  await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Forward the authenticated user to server components via a request header
+  // so pages never need to call getSession() / getUser() themselves.
+  // Always set the header (empty when unauthenticated) to prevent client spoofing.
+  request.headers.set(
+    "x-supabase-user",
+    user ? JSON.stringify(user) : "",
+  );
+
+  // Rebuild the response so it picks up the new request header,
+  // then copy over any Set-Cookie headers from the token refresh.
+  const setCookies = supabaseResponse.headers.getSetCookie();
+  supabaseResponse = NextResponse.next({ request });
+  setCookies.forEach((c) =>
+    supabaseResponse.headers.append("Set-Cookie", c),
+  );
 
   return supabaseResponse;
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 export async function createClient() {
   const cookieStore = await cookies();
 
-  return createServerClient(
+  const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -25,4 +25,6 @@ export async function createClient() {
       },
     },
   );
+
+  return supabase;
 }

--- a/lib/supabase/user.ts
+++ b/lib/supabase/user.ts
@@ -1,0 +1,17 @@
+import { headers } from "next/headers";
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Reads the authenticated user forwarded by middleware via the
+ * `x-supabase-user` request header.  No network call — instant.
+ */
+export async function getUser(): Promise<User | null> {
+    const h = await headers();
+    const raw = h.get("x-supabase-user");
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw) as User;
+    } catch {
+        return null;
+    }
+}


### PR DESCRIPTION
Commit 1:

Middleware already validates and refreshes the JWT on every request. Page components now use getSession() which reads the token from cookies locally (no network call) instead of getUser() which makes a round-trip to Supabase auth servers (~150-300ms).

Server actions (mutations) still use getUser() for full server-side validation since they modify data.


Page | Before | After | Improvement
-- | -- | -- | --
/softball | 494ms | 461ms | Stable, no spikes
/softball/session/[id] | 1328ms, 1857ms | 516ms | ~60% faster
/softball/admin (upcoming) | 1018ms | 799ms | ~20% faster
/softball/admin?tab=create | 833ms | 349ms | ~58% faster
/softball/admin?tab=requests | 736ms | 409ms | ~44% faster

This gives a Supabase "insecure getSession" warning.

Commit 2: 

Forward authenticated user from middleware via request header
Middleware already validates the JWT via getUser() on every request. Instead of pages redundantly calling getSession(), the middleware now serializes the user into an x-supabase-user request header. Pages read it instantly via headers() — zero auth calls, no Supabase "insecure getSession" warning.

Commit 3:
For session details, parallelize DB calls since each DB call takes 200ms.