### PR TITLE
feat: add umpiring and dynamic session types

### DIFF
--- a/components/sports/session-card.tsx
+++ b/components/sports/session-card.tsx
@@ -14,7 +14,7 @@ import CountdownTimer from "@/components/sports/countdown-timer";
 import { formatDate, formatTime } from "@/lib/format";
 import { isSignupOpen } from "@/lib/signup-capacity";
 import { cn } from "@/lib/utils";
-import { sessionTypeLabels } from "@/config/sports-config";
+import { sportsConfig, getSessionTypeLabel, getDefaultTitlePrefix } from "@/config/sports-config";
 import type { SignupStatus, SportSession } from "@/lib/supabase/types";
 
 interface SessionCardProps {
@@ -48,8 +48,10 @@ export default function SessionCard({
     ? { label: "Upcoming", variant: "secondary" as const }
     : getSignupStatus(session);
   const href = `/${session.sport}/session/${session.id}`;
-  const fallbackTitle = `${sessionTypeLabels[session.session_type] ?? "Session"
-    }: ${formatDate(session.date, "short", true)}`;
+  const sportConfig = sportsConfig[session.sport];
+  const prefix = getDefaultTitlePrefix(sportConfig, session.session_type)
+    ?? getSessionTypeLabel(sportConfig, session.session_type);
+  const fallbackTitle = `${prefix}: ${formatDate(session.date, "short", true)}`;
   const displayTitle = session.title || fallbackTitle;
 
   const card = (

--- a/components/sports/session-form.tsx
+++ b/components/sports/session-form.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { createSession, type CreateSessionResult } from "@/lib/actions/sessions";
-import type { SessionType } from "@/lib/supabase/types";
+import { sportsConfig } from "@/config/sports-config";
 
 interface SessionFormProps {
   sport: string;
@@ -26,8 +26,11 @@ export default function SessionForm({ sport }: SessionFormProps) {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
+  const sportConfig = sportsConfig[sport];
+  const tabs = sportConfig?.tabs ?? [];
+  const defaultSessionType = sportConfig?.defaultTab ?? tabs[0]?.value ?? "";
   const [sessionType, setSessionType] =
-    useState<SessionType>("drop_in_practice");
+    useState(defaultSessionType);
 
   const autoFillSignupClose = (form: HTMLFormElement) => {
     const date = (form.elements.namedItem("date") as HTMLInputElement)?.value;
@@ -138,7 +141,7 @@ export default function SessionForm({ sport }: SessionFormProps) {
         className: toastClasses.green,
       });
       (e.target as HTMLFormElement).reset();
-      setSessionType("drop_in_practice");
+      setSessionType(defaultSessionType);
     }
     setPending(false);
   };
@@ -154,14 +157,15 @@ export default function SessionForm({ sport }: SessionFormProps) {
           <Label htmlFor="session_type">Session Type</Label>
           <Select
             value={sessionType}
-            onValueChange={(v) => setSessionType(v as SessionType)}
+            onValueChange={(v) => setSessionType(v)}
           >
             <SelectTrigger id="session_type">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="drop_in_practice">Drop-in Practice</SelectItem>
-              <SelectItem value="scheduled_game">Scheduled Game</SelectItem>
+              {tabs.map((tab) => (
+                <SelectItem key={tab.value} value={tab.value}>{tab.label}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -18,6 +18,8 @@ export interface SessionTab {
   value: string;
   label: string;
   restrictedAccess?: boolean;
+  /** Default prefix for session titles */
+  defaultTitlePrefix?: string;
 }
 
 export interface AdminTabMeta {
@@ -61,10 +63,15 @@ export function hasRestrictedAccess(config: SportConfig | undefined): boolean {
   return config?.tabs?.some((t) => t.restrictedAccess) ?? false;
 }
 
-export const sessionTypeLabels: Record<string, string> = {
-  drop_in_practice: "Practice",
-  scheduled_game: "Game",
-};
+/** Look up the tab label for a session type from sportsConfig. */
+export function getSessionTypeLabel(config: SportConfig | undefined, sessionType: string): string {
+  return config?.tabs?.find((t) => t.value === sessionType)?.label ?? sessionType;
+}
+
+/** Look up the default title prefix for a session type from sportsConfig. */
+export function getDefaultTitlePrefix(config: SportConfig | undefined, sessionType: string): string | undefined {
+  return config?.tabs?.find((t) => t.value === sessionType)?.defaultTitlePrefix;
+}
 
 export const sportsConfig: Record<string, SportConfig> = {
   basketball: {
@@ -179,8 +186,8 @@ export const sportsConfig: Record<string, SportConfig> = {
     description: "Join us for Drop-in Practices. Scheduled Games are only open to confirmed CCSA Team Members.",
     defaultTab: "drop_in_practice",
     tabs: [
-      { value: "scheduled_game", label: "Scheduled Games", restrictedAccess: true },
-      { value: "drop_in_practice", label: "Drop-in Practice" },
+      { value: "drop_in_practice", label: "Drop-in Practice", defaultTitlePrefix: "Practice" },
+      { value: "scheduled_game", label: "Scheduled Games", restrictedAccess: true, defaultTitlePrefix: "Game" },
       { value: "umpiring", label: "Umpiring", restrictedAccess: true },
     ],
   },

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -181,6 +181,7 @@ export const sportsConfig: Record<string, SportConfig> = {
     tabs: [
       { value: "scheduled_game", label: "Scheduled Games", restrictedAccess: true },
       { value: "drop_in_practice", label: "Drop-in Practice" },
+      { value: "umpiring", label: "Umpiring", restrictedAccess: true },
     ],
   },
 } satisfies Record<string, SportConfig>;

--- a/lib/actions/sessions.ts
+++ b/lib/actions/sessions.ts
@@ -3,10 +3,9 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { requireSportAdmin } from "@/lib/supabase/user";
-import type { SessionType } from "@/lib/supabase/types";
 
 export interface CreateSessionInput {
-  session_type: SessionType;
+  session_type: string;
   title?: string;
   date: string;
   time_start: string;

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -21,12 +21,10 @@ export interface SportRole {
   created_at: string;
 }
 
-export type SessionType = "scheduled_game" | "drop_in_practice";
-
 export interface SportSession {
   id: string;
   sport: string;
-  session_type: SessionType;
+  session_type: string;
   title: string | null;
   date: string;
   time_start: string;

--- a/supabase/migrations/20260328181039_initial_schema.sql
+++ b/supabase/migrations/20260328181039_initial_schema.sql
@@ -67,7 +67,7 @@ create trigger on_auth_user_created
 create table public.sessions (
   id              uuid primary key default gen_random_uuid(),
   sport           text not null,
-  session_type    text not null check (session_type in ('scheduled_game', 'drop_in_practice')),
+  session_type    text not null,
   title           text,
   date            date not null,
   time_start      time not null,


### PR DESCRIPTION
1. feat: add umpiring tab and drop session_type check constraint — config, schema, types, helpers
2. refactor: replace hardcoded SessionType with sportsConfig-driven session types — component updates