### PR TITLE
feat: Declarative Tab Permissions System & Config Defaults

### DIFF
--- a/app/[sport]/admin/page.tsx
+++ b/app/[sport]/admin/page.tsx
@@ -16,6 +16,7 @@ import {
   getDefaultTitlePrefix,
   getSessionTypeLabel,
   sportsConfig,
+  Role,
   type SportConfig,
 } from "@/config/sports-config";
 import AdminSessionSignups from "@/components/sports/admin-session-signups";
@@ -321,8 +322,8 @@ export default async function AdminPage({
 
   if (!user) redirect(`/${sport}`);
 
-  const { isAdmin } = await getUserSportRole(supabase, user.id, sport);
-  if (!isAdmin) redirect(`/${sport}`);
+  const { role } = await getUserSportRole(supabase, user.id, sport);
+  if (role < Role.admin) redirect(`/${sport}`);
 
   return (
     <div className="max-w-full px-4 sm:px-6 lg:px-8 mx-auto mb-12 space-y-6">

--- a/app/[sport]/admin/page.tsx
+++ b/app/[sport]/admin/page.tsx
@@ -16,7 +16,6 @@ import {
   resolvedSportsConfig,
   getResolvedTab,
   Role,
-  AccessLevel,
   type ResolvedSportConfig,
 } from "@/config/config-resolver";
 import AdminSessionSignups from "@/components/sports/admin-session-signups";

--- a/app/[sport]/admin/page.tsx
+++ b/app/[sport]/admin/page.tsx
@@ -13,12 +13,12 @@ import { CalendarDays, MapPin } from "lucide-react";
 import PageHeader from "@/components/sports/page-header";
 import SessionForm from "@/components/sports/session-form";
 import {
-  getDefaultTitlePrefix,
-  getSessionTypeLabel,
-  sportsConfig,
+  resolvedSportsConfig,
+  getResolvedTab,
   Role,
-  type SportConfig,
-} from "@/config/sports-config";
+  AccessLevel,
+  type ResolvedSportConfig,
+} from "@/config/config-resolver";
 import AdminSessionSignups from "@/components/sports/admin-session-signups";
 import AdminAccessRequests from "@/components/sports/admin-access-requests";
 import DeleteSessionButton from "@/components/sports/delete-session-button";
@@ -50,7 +50,7 @@ function SessionAccordion({
   teamMemberIds,
   muted,
 }: {
-  config: SportConfig;
+  config: ResolvedSportConfig;
   sport: string;
   sessions: SportSession[];
   signupsBySession: Map<
@@ -80,9 +80,9 @@ function SessionAccordion({
         const activeCount = sessionSignups.filter(
           (s) => s.status !== "cancelled",
         ).length;
+        const tab = getResolvedTab(config, session.session_type);
         const sessionTypeLabel =
-          getDefaultTitlePrefix(config, session.session_type) ??
-          getSessionTypeLabel(config, session.session_type);
+          tab.defaultTitlePrefix ?? tab.label;
 
         return (
           <AccordionItem
@@ -165,7 +165,7 @@ async function AdminDataContent({
   sport: string;
   tab: string;
 }) {
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
 
   // ── Fetch cached data in parallel ──────────────────────────────
   const [sessions, accessRequests, teamMemberIds] = await Promise.all([
@@ -312,7 +312,7 @@ export default async function AdminPage({
   searchParams: Promise<{ tab?: string }>;
 }) {
   const { sport } = await params;
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
   if (!config) notFound();
 
   const { tab = "upcoming" } = await searchParams;

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -10,7 +10,7 @@ import TeamAccessBanner from "@/components/sports/team-access-banner";
 import SignInToSignupBanner from "@/components/sports/sign-in-to-signup-banner";
 import SportPageShell from "@/components/sports/sport-page-shell";
 import { Button } from "@/components/ui/button";
-import { sportsConfig, hasRestrictedAccess, Role, AccessLevel, getTabPermissions } from "@/config/sports-config";
+import { resolvedSportsConfig, Role, AccessLevel } from "@/config/config-resolver";
 import { LoadingContent } from "@/components/sports/loading-content";
 import { getUpcomingSessions, getUserAccessRequestStatus, getUserSignupStatuses } from "@/lib/get-data";
 import type { SignupStatus } from "@/lib/supabase/types";
@@ -28,7 +28,7 @@ async function SportSessionsContent({
   scrollTo?: string;
   userId: string | null;
 }) {
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
   const supabase = await createClient();
 
   // ── Roles & sessions (parallel) ────────────────────────────────
@@ -39,12 +39,15 @@ async function SportSessionsContent({
     getUpcomingSessions(sport),
   ]);
 
-  const { isTeamMember } = roleResult;
-  const userRole: Role = 'role' in roleResult ? (roleResult as { role: Role }).role : (userId ? Role.user : Role.anon);
+  const userRole = roleResult.role;
   let accessRequestStatus: "pending" | "approved" | "rejected" | null = null;
 
-  if (userId && hasRestrictedAccess(config) && !isTeamMember) {
-    accessRequestStatus = await getUserAccessRequestStatus(userId, sport);
+  const showTeamAccessBanner = !!userId && config.tabs.some((t) =>
+    userRole < t.permissions[AccessLevel.signup]
+  );
+
+  if (showTeamAccessBanner) {
+    accessRequestStatus = await getUserAccessRequestStatus(userId!, sport);
   }
 
   const sessionIds = sessionsWithCounts.map((session) => session.id);
@@ -133,10 +136,8 @@ async function SportSessionsContent({
     validValues.find((v) => v === resolvedValue) ??
     (showAll ? ALL_VALUE : config.defaultTab ?? configTabs[0]?.value);
 
-  const showTeamAccessBanner =
-    !!userId && hasRestrictedAccess(config) && !isTeamMember;
   const showSignInBanner =
-    !userId && !!config.authEnabled && hasRestrictedAccess(config);
+    !userId && !!config.authEnabled && config.hasRestrictedAccess;
 
   return (
     <div className="space-y-4">
@@ -182,7 +183,7 @@ export default async function SportAuthPage({
   searchParams: Promise<{ tab?: string; highlight?: string; session?: string }>;
 }) {
   const { sport } = await params;
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
   if (!config) notFound();
 
   const { tab, highlight, session } = await searchParams;

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -35,7 +35,7 @@ async function SportSessionsContent({
   const [roleResult, sessionsWithCounts] = await Promise.all([
     userId
       ? getUserSportRole(supabase, userId, sport)
-      : Promise.resolve({ isAdmin: false, isTeamMember: false }),
+      : Promise.resolve({ role: Role.anon, isAdmin: false, isTeamMember: false }),
     getUpcomingSessions(sport),
   ]);
 
@@ -162,8 +162,8 @@ async function SportSessionsContent({
 
 async function AdminButton({ sport, userId }: { sport: string; userId: string }) {
   const supabase = await createClient();
-  const { isAdmin } = await getUserSportRole(supabase, userId, sport);
-  if (!isAdmin) return null;
+  const { role } = await getUserSportRole(supabase, userId, sport);
+  if (role < Role.admin) return null;
   return (
     <Button asChild variant="outline" size="sm" className="rounded-full">
       <Link href={`/${sport}/admin`}>

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -10,7 +10,7 @@ import TeamAccessBanner from "@/components/sports/team-access-banner";
 import SignInToSignupBanner from "@/components/sports/sign-in-to-signup-banner";
 import SportPageShell from "@/components/sports/sport-page-shell";
 import { Button } from "@/components/ui/button";
-import { sportsConfig, hasRestrictedAccess } from "@/config/sports-config";
+import { sportsConfig, hasRestrictedAccess, Role, AccessLevel, getTabPermissions } from "@/config/sports-config";
 import { LoadingContent } from "@/components/sports/loading-content";
 import { getUpcomingSessions, getUserAccessRequestStatus, getUserSignupStatuses } from "@/lib/get-data";
 import type { SignupStatus } from "@/lib/supabase/types";
@@ -40,6 +40,7 @@ async function SportSessionsContent({
   ]);
 
   const { isTeamMember } = roleResult;
+  const userRole: Role = 'role' in roleResult ? (roleResult as { role: Role }).role : (userId ? Role.user : Role.anon);
   let accessRequestStatus: "pending" | "approved" | "rejected" | null = null;
 
   if (userId && hasRestrictedAccess(config) && !isTeamMember) {
@@ -74,6 +75,7 @@ async function SportSessionsContent({
                   session={session}
                   highlighted={session.id === highlight}
                   returnTab={t.value}
+                  userRole={userRole}
                   userSignupStatus={
                     userSignupStatusBySession.get(session.id) ?? null
                   }
@@ -104,6 +106,7 @@ async function SportSessionsContent({
                   session={session}
                   highlighted={session.id === highlight}
                   returnTab={ALL_VALUE}
+                  userRole={userRole}
                   userSignupStatus={
                     userSignupStatusBySession.get(session.id) ?? null
                   }

--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -141,7 +141,7 @@ export default async function SessionDetailPage({
     redirect(`/${sport}`);
   }
 
-  const { isAdmin } = roleResult;
+  const isAdmin = userRole >= Role.admin;
 
   const sessionTab = config.tabs?.find((t) => t.value === session.session_type);
   const isOpen = isSignupOpen(session);

--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -21,7 +21,7 @@ import SessionSignupsTable from "@/components/sports/session-signups-table";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
 import { Button } from "@/components/ui/button";
-import { sportsConfig, getTabPermissions, Role, AccessLevel } from "@/config/sports-config";
+import { resolvedSportsConfig, getResolvedTab, Role, AccessLevel } from "@/config/config-resolver";
 import { formatDate, formatTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
@@ -54,7 +54,7 @@ async function SessionSignupsContent({
 }) {
   const userId = user?.id ?? null;
   const canSignup = userRole >= signupRole;
-  const needsTeamAccess = signupRole >= Role.teamUser && userRole < Role.teamUser && userRole >= Role.user;
+  const needsTeamAccess = !!user && userRole < signupRole;
 
   const [rawSignups, teamMemberIds, userSignupStatus, accessRequestStatus] =
     await Promise.all([
@@ -73,7 +73,7 @@ async function SessionSignupsContent({
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        {userRole === Role.anon && signupRole >= Role.user && (
+        {!user && signupRole > userRole && (
           <SignInToSignupBanner />
         )}
         {showTeamGate && (
@@ -117,7 +117,7 @@ export default async function SessionDetailPage({
 }) {
   const { sport, id } = await params;
   const { fromTab } = await searchParams;
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
   if (!config) notFound();
 
   const supabase = await createClient();
@@ -132,20 +132,19 @@ export default async function SessionDetailPage({
   ]);
 
   // Redirect to sport page if session doesn't exist or user lacks view access
-  const permissions = getTabPermissions(config, session?.session_type ?? "");
+  const tab = getResolvedTab(config, session?.session_type ?? "");
   const userRole = user
     ? roleResult.role
     : Role.anon;
 
-  if (!session || userRole < permissions[AccessLevel.view]) {
+  if (!session || userRole < tab.permissions[AccessLevel.view]) {
     redirect(`/${sport}`);
   }
 
-  const isAdmin = userRole >= Role.admin;
+  const isAdmin = userRole >= tab.permissions[AccessLevel.admin];
 
-  const sessionTab = config.tabs?.find((t) => t.value === session.session_type);
   const isOpen = isSignupOpen(session);
-  const sessionTypeLabel = sessionTab?.label ?? session.session_type;
+  const sessionTypeLabel = tab.label;
   const backParams = new URLSearchParams({ session: id });
   if (fromTab) backParams.set("tab", fromTab);
 
@@ -282,7 +281,7 @@ export default async function SessionDetailPage({
           user={user}
           isOpen={isOpen}
           userRole={userRole}
-          signupRole={permissions[AccessLevel.signup]}
+          signupRole={tab.permissions[AccessLevel.signup]}
           playerCap={session.player_cap}
         />
       </Suspense>

--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { getUser, getUserSportRole } from "@/lib/supabase/user";
@@ -21,7 +21,7 @@ import SessionSignupsTable from "@/components/sports/session-signups-table";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
 import { Button } from "@/components/ui/button";
-import { sportsConfig, hasRestrictedAccess, isRestrictedSessionType } from "@/config/sports-config";
+import { sportsConfig, getTabPermissions, Role, AccessLevel } from "@/config/sports-config";
 import { formatDate, formatTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
@@ -40,57 +40,40 @@ async function SessionSignupsContent({
   sport,
   user,
   isOpen,
-  isTeamMember,
-  isRestrictedSession,
+  userRole,
+  signupRole,
   playerCap,
-  authEnabled,
 }: {
   sessionId: string;
   sport: string;
   user: User | null;
   isOpen: boolean;
-  isTeamMember: boolean;
-  isRestrictedSession: boolean;
+  userRole: Role;
+  signupRole: Role;
   playerCap: number | null;
-  authEnabled: boolean;
 }) {
   const userId = user?.id ?? null;
-  const sportCfg = sportsConfig[sport];
-  const fetchAccessStatus =
-    !!userId &&
-    authEnabled &&
-    isRestrictedSession &&
-    !isTeamMember &&
-    hasRestrictedAccess(sportCfg);
+  const canSignup = userRole >= signupRole;
+  const needsTeamAccess = signupRole >= Role.teamUser && userRole < Role.teamUser && userRole >= Role.user;
 
   const [rawSignups, teamMemberIds, userSignupStatus, accessRequestStatus] =
     await Promise.all([
       getSessionSignups(sessionId),
       getTeamMembers(sport),
       userId ? getUserSignupStatus(userId, sessionId) : Promise.resolve(null),
-      fetchAccessStatus
+      needsTeamAccess
         ? getUserAccessRequestStatus(userId!, sport)
         : Promise.resolve(null),
     ]);
 
   const requestApproved = accessRequestStatus === "approved";
-  const showTeamGate =
-    !!userId &&
-    authEnabled &&
-    isRestrictedSession &&
-    !isTeamMember &&
-    !requestApproved;
-  const showSignupButton =
-    !!userId &&
-    (!authEnabled ||
-      !isRestrictedSession ||
-      isTeamMember ||
-      requestApproved);
+  const showTeamGate = needsTeamAccess && !requestApproved;
+  const showSignupButton = canSignup || requestApproved;
 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        {authEnabled && !userId && (
+        {userRole === Role.anon && signupRole >= Role.user && (
           <SignInToSignupBanner />
         )}
         {showTeamGate && (
@@ -145,14 +128,22 @@ export default async function SessionDetailPage({
     getSession(id),
     user
       ? getUserSportRole(supabase, user.id, sport)
-      : Promise.resolve({ isAdmin: false, isTeamMember: false }),
+      : Promise.resolve({ role: Role.anon, isAdmin: false, isTeamMember: false }),
   ]);
 
-  if (!session) notFound();
-  const { isAdmin, isTeamMember } = roleResult;
+  // Redirect to sport page if session doesn't exist or user lacks view access
+  const permissions = getTabPermissions(config, session?.session_type ?? "");
+  const userRole = user
+    ? roleResult.role
+    : Role.anon;
+
+  if (!session || userRole < permissions[AccessLevel.view]) {
+    redirect(`/${sport}`);
+  }
+
+  const { isAdmin } = roleResult;
 
   const sessionTab = config.tabs?.find((t) => t.value === session.session_type);
-  const isRestrictedSession = isRestrictedSessionType(config, session.session_type);
   const isOpen = isSignupOpen(session);
   const sessionTypeLabel = sessionTab?.label ?? session.session_type;
   const backParams = new URLSearchParams({ session: id });
@@ -290,10 +281,9 @@ export default async function SessionDetailPage({
           sport={sport}
           user={user}
           isOpen={isOpen}
-          isTeamMember={isTeamMember}
-          isRestrictedSession={isRestrictedSession}
+          userRole={userRole}
+          signupRole={permissions[AccessLevel.signup]}
           playerCap={session.player_cap}
-          authEnabled={!!config.authEnabled}
         />
       </Suspense>
     </div>

--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -21,7 +21,7 @@ import SessionSignupsTable from "@/components/sports/session-signups-table";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
 import { Button } from "@/components/ui/button";
-import { sportsConfig, hasRestrictedAccess } from "@/config/sports-config";
+import { sportsConfig, hasRestrictedAccess, isRestrictedSessionType } from "@/config/sports-config";
 import { formatDate, formatTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
@@ -152,7 +152,7 @@ export default async function SessionDetailPage({
   const { isAdmin, isTeamMember } = roleResult;
 
   const sessionTab = config.tabs?.find((t) => t.value === session.session_type);
-  const isRestrictedSession = !!sessionTab?.restrictedAccess;
+  const isRestrictedSession = isRestrictedSessionType(config, session.session_type);
   const isOpen = isSignupOpen(session);
   const sessionTypeLabel = sessionTab?.label ?? session.session_type;
   const backParams = new URLSearchParams({ session: id });

--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getScheduleData, getFormResponses } from "@/lib/schedule-utils";
-import { sportsConfig } from "@/config/sports-config";
+import { resolvedSportsConfig } from "@/config/config-resolver";
 import { getUser } from "@/lib/supabase/user";
 import SportPage from "@/components/sports/sport-page";
 
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 const sport = "basketball";
 
 export default async function BasketballPage() {
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
 
   if (!config) notFound();
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,11 @@ import {
 } from "@/components/ui/card";
 import { buttonVariants } from "@/components/ui/button";
 import { ArrowRight, CalendarDays, Clock, Users } from "lucide-react";
-import { sportsConfig } from "@/config/sports-config";
+import { resolvedSportsConfig } from "@/config/config-resolver";
 import { cn } from "@/lib/utils";
 
 export default function Home() {
-  const sports = Object.values(sportsConfig);
+  const sports = Object.values(resolvedSportsConfig);
 
   return (
     <div className="max-w-4xl mx-auto mb-12 space-y-6">

--- a/app/volleyball/page.tsx
+++ b/app/volleyball/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getScheduleData, getFormResponses } from "@/lib/schedule-utils";
-import { sportsConfig } from "@/config/sports-config";
+import { resolvedSportsConfig } from "@/config/config-resolver";
 import { getUser } from "@/lib/supabase/user";
 import SportPage from "@/components/sports/sport-page";
 
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 const sport = "volleyball";
 
 export default async function VolleyballPage() {
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
 
   if (!config) notFound();
 

--- a/components/sports/admin-sidebar.tsx
+++ b/components/sports/admin-sidebar.tsx
@@ -7,7 +7,7 @@ import {
   ClipboardList, Plus, Calendar, History,
   RefreshCw, type LucideIcon,
 } from "lucide-react";
-import type { AdminTabMeta } from "@/config/sports-config";
+import type { AdminTabMeta } from "@/config/config-resolver";
 
 /** Map from iconName strings in sports-config to actual Lucide components. */
 const iconMap: Record<string, LucideIcon> = {

--- a/components/sports/session-card.tsx
+++ b/components/sports/session-card.tsx
@@ -15,7 +15,7 @@ import { formatDate, formatTime } from "@/lib/format";
 import { isSignupOpen } from "@/lib/signup-capacity";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
-import { sportsConfig, getSessionTypeLabel, getDefaultTitlePrefix } from "@/config/sports-config";
+import { sportsConfig, getSessionTypeLabel, getDefaultTitlePrefix, getTabPermissions, AccessLevel, Role } from "@/config/sports-config";
 import type { SignupStatus, SportSession } from "@/lib/supabase/types";
 
 interface SessionCardProps {
@@ -23,6 +23,7 @@ interface SessionCardProps {
   highlighted?: boolean;
   userSignupStatus?: SignupStatus | null;
   returnTab?: string;
+  userRole?: Role;
 }
 
 function getSignupStatus(session: SportSession): {
@@ -43,13 +44,16 @@ export default function SessionCard({
   highlighted,
   userSignupStatus,
   returnTab,
+  userRole,
 }: SessionCardProps) {
   const isOpen = isSignupOpen(session);
   const status = getSignupStatus(session);
+  const sportConfig = sportsConfig[session.sport];
+  const permissions = getTabPermissions(sportConfig, session.session_type);
+  const canView = userRole === undefined || userRole >= permissions[AccessLevel.view];
   const href = returnTab
     ? `/${session.sport}/session/${session.id}?fromTab=${encodeURIComponent(returnTab)}`
     : `/${session.sport}/session/${session.id}`;
-  const sportConfig = sportsConfig[session.sport];
   const sessionTypeLabel = getSessionTypeLabel(sportConfig, session.session_type);
   const prefix = getDefaultTitlePrefix(sportConfig, session.session_type)
     ?? sessionTypeLabel;
@@ -58,21 +62,25 @@ export default function SessionCard({
 
   const card = (
     <Card className={cn(
-      "relative flex h-full flex-col gap-2 overflow-hidden transition-shadow hover:shadow-lg",
+      "relative flex h-full flex-col gap-2 overflow-hidden transition-shadow",
+      canView && "hover:shadow-lg",
+      !canView && "opacity-60 cursor-default",
       highlighted && "ring-2 ring-blue-500 bg-blue-50/50",
     )}>
-      <Link
-        href={href}
-        onClick={() => {
-          if (!returnTab) return;
-          sessionStorage.setItem(
-            `last-session:${session.sport}`,
-            JSON.stringify({ sessionId: session.id, tab: returnTab }),
-          );
-        }}
-        className="absolute inset-0 z-10"
-        aria-label={`View ${displayTitle} details`}
-      />
+      {canView && (
+        <Link
+          href={href}
+          onClick={() => {
+            if (!returnTab) return;
+            sessionStorage.setItem(
+              `last-session:${session.sport}`,
+              JSON.stringify({ sessionId: session.id, tab: returnTab }),
+            );
+          }}
+          className="absolute inset-0 z-10"
+          aria-label={`View ${displayTitle} details`}
+        />
+      )}
       <CardHeader className="relative z-20 pb-0 pointer-events-none">
         <div className="flex items-start justify-between gap-2">
           <div className="space-y-2">

--- a/components/sports/session-card.tsx
+++ b/components/sports/session-card.tsx
@@ -15,7 +15,7 @@ import { formatDate, formatTime } from "@/lib/format";
 import { isSignupOpen } from "@/lib/signup-capacity";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
-import { sportsConfig, getSessionTypeLabel, getDefaultTitlePrefix, getTabPermissions, AccessLevel, Role } from "@/config/sports-config";
+import { resolvedSportsConfig, getResolvedTab, AccessLevel, Role } from "@/config/config-resolver";
 import type { SignupStatus, SportSession } from "@/lib/supabase/types";
 
 interface SessionCardProps {
@@ -48,15 +48,15 @@ export default function SessionCard({
 }: SessionCardProps) {
   const isOpen = isSignupOpen(session);
   const status = getSignupStatus(session);
-  const sportConfig = sportsConfig[session.sport];
-  const permissions = getTabPermissions(sportConfig, session.session_type);
-  const canView = userRole === undefined || userRole >= permissions[AccessLevel.view];
+  const sportConfig = resolvedSportsConfig[session.sport];
+  const tab = getResolvedTab(sportConfig, session.session_type);
+  const canView = userRole === undefined || userRole >= tab.permissions[AccessLevel.view];
+  const canSignup = userRole === undefined || userRole >= tab.permissions[AccessLevel.signup];
   const href = returnTab
     ? `/${session.sport}/session/${session.id}?fromTab=${encodeURIComponent(returnTab)}`
     : `/${session.sport}/session/${session.id}`;
-  const sessionTypeLabel = getSessionTypeLabel(sportConfig, session.session_type);
-  const prefix = getDefaultTitlePrefix(sportConfig, session.session_type)
-    ?? sessionTypeLabel;
+  const sessionTypeLabel = tab.label;
+  const prefix = tab.defaultTitlePrefix ?? sessionTypeLabel;
   const fallbackTitle = `${prefix}: ${formatDate(session.date, "short", true)}`;
   const displayTitle = session.title || fallbackTitle;
 
@@ -103,9 +103,11 @@ export default function SessionCard({
               userSignupStatus === "declined") && (
                 <StatusBadge status={userSignupStatus} />
               )}
-            <Badge variant={status.variant} className="shrink-0">
-              {status.label}
-            </Badge>
+            {canSignup && (
+              <Badge variant={status.variant} className="shrink-0">
+                {status.label}
+              </Badge>
+            )}
           </div>
         </div>
       </CardHeader>
@@ -125,13 +127,15 @@ export default function SessionCard({
           <MapPin className="h-4 w-4 shrink-0" />
           <span>{session.location_name}</span>
         </div>
-        <div className="flex items-center gap-2">
-          <Users className="h-4 w-4 shrink-0" />
-          <span>
-            {session.signup_count}{session.player_cap ? ` / ${session.player_cap}` : " signed up"}
-          </span>
-        </div>
-        {session.signup_open && session.signup_close && (
+        {canSignup && (
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 shrink-0" />
+            <span>
+              {session.signup_count}{session.player_cap ? ` / ${session.player_cap}` : " signed up"}
+            </span>
+          </div>
+        )}
+        {canSignup && session.signup_open && session.signup_close && (
           <CountdownTimer
             openTime={session.signup_open}
             closeTime={session.signup_close}

--- a/components/sports/session-form.tsx
+++ b/components/sports/session-form.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { createSession, type CreateSessionResult } from "@/lib/actions/sessions";
-import { sportsConfig } from "@/config/sports-config";
+import { resolvedSportsConfig } from "@/config/config-resolver";
 
 interface SessionFormProps {
   sport: string;
@@ -26,7 +26,7 @@ export default function SessionForm({ sport }: SessionFormProps) {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
-  const sportConfig = sportsConfig[sport];
+  const sportConfig = resolvedSportsConfig[sport];
   const tabs = sportConfig?.tabs ?? [];
   const defaultSessionType = sportConfig?.defaultTab ?? tabs[0]?.value ?? "";
   const [sessionType, setSessionType] =

--- a/components/sports/session-signups-table.tsx
+++ b/components/sports/session-signups-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import {
   Table,
   TableBody,
@@ -86,15 +86,15 @@ export default function SessionSignupsTable({
                 const groupIndex = isDeclined ? ++declinedIndex : ++activeIndex;
                 const showDivider = isDeclined && declinedIndex === 1;
                 return (
-                  <>
+                  <Fragment key={signup.id}>
                     {showDivider && (
-                      <TableRow key="divider" className="pointer-events-none">
+                      <TableRow className="pointer-events-none">
                         <TableCell colSpan={colCount} className="py-1 px-4">
                           <div className="border-t border-dashed border-gray-300" />
                         </TableCell>
                       </TableRow>
                     )}
-                    <TableRow key={signup.id} className={`group ${isCurrentUser ? "bg-blue-50" : ""}`}>
+                    <TableRow className={`group ${isCurrentUser ? "bg-blue-50" : ""}`}>
                       <TableCell className="font-mono text-xs">
                         {groupIndex}
                       </TableCell>
@@ -118,7 +118,7 @@ export default function SessionSignupsTable({
                         </TableCell>
                       )}
                     </TableRow>
-                  </>
+                  </Fragment>
                 );
               });
             })()}

--- a/components/sports/sport-page-shell.tsx
+++ b/components/sports/sport-page-shell.tsx
@@ -2,7 +2,7 @@ import AuthButton from "@/components/sports/auth-button";
 import PageHeader from "@/components/sports/page-header";
 import type { User } from "@supabase/supabase-js";
 import type { ReactNode } from "react";
-import { sportsConfig } from "@/config/sports-config";
+import { resolvedSportsConfig } from "@/config/config-resolver";
 
 interface SportPageShellProps {
     user: User | null;
@@ -19,7 +19,7 @@ export default function SportPageShell({
     showDescription = true,
     children,
 }: SportPageShellProps) {
-    const config = sportsConfig[sport];
+    const config = resolvedSportsConfig[sport];
 
     return (
         <div className="max-w-4xl mx-auto mb-12 space-y-6">

--- a/components/sports/sport-page.tsx
+++ b/components/sports/sport-page.tsx
@@ -10,7 +10,7 @@ import {
   UserStar,
 } from "lucide-react";
 import { ScheduleData } from "@/lib/schedule-utils";
-import { SportConfig } from "@/config/sports-config";
+import { SportConfig } from "@/config/config-resolver";
 import { formatDate } from "@/lib/format";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import SignupsTable from "@/components/sports/signups-table";

--- a/components/sports/team-access-banner.tsx
+++ b/components/sports/team-access-banner.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Shield, Clock, XCircle } from "lucide-react";
 import { requestTeamAccess } from "@/lib/actions/team-access";
-import { sportsConfig } from "@/config/sports-config";
+import { sportsConfig, getTabPermissions, AccessLevel, Role } from "@/config/sports-config";
 import type { AccessRequestStatus } from "@/lib/supabase/types";
 import { colors, statusColors } from "@/lib/styles";
 
@@ -16,7 +16,7 @@ interface TeamAccessBannerProps {
 function getRestrictedTabLabels(sport: string): string {
   const config = sportsConfig[sport];
   const labels = config?.tabs
-    ?.filter((t) => t.restrictedAccess)
+    ?.filter((t) => getTabPermissions(config, t.value)[AccessLevel.signup] >= Role.teamUser)
     .map((t) => t.label.toLowerCase()) ?? [];
   if (labels.length === 0) return "restricted sessions";
   if (labels.length === 1) return labels[0];

--- a/components/sports/team-access-banner.tsx
+++ b/components/sports/team-access-banner.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Shield, Clock, XCircle } from "lucide-react";
 import { requestTeamAccess } from "@/lib/actions/team-access";
-import { sportsConfig, getTabPermissions, AccessLevel, Role } from "@/config/sports-config";
+import { resolvedSportsConfig, AccessLevel, Role } from "@/config/config-resolver";
 import type { AccessRequestStatus } from "@/lib/supabase/types";
 import { colors, statusColors } from "@/lib/styles";
 
@@ -14,9 +14,9 @@ interface TeamAccessBannerProps {
 }
 
 function getRestrictedTabLabels(sport: string): string {
-  const config = sportsConfig[sport];
+  const config = resolvedSportsConfig[sport];
   const labels = config?.tabs
-    ?.filter((t) => getTabPermissions(config, t.value)[AccessLevel.signup] >= Role.teamUser)
+    ?.filter((t) => t.permissions[AccessLevel.signup] > Role.user)
     .map((t) => t.label.toLowerCase()) ?? [];
   if (labels.length === 0) return "restricted sessions";
   if (labels.length === 1) return labels[0];

--- a/config/config-interfaces.ts
+++ b/config/config-interfaces.ts
@@ -1,0 +1,97 @@
+import type { Sport, FormResponseColumn } from "@/lib/schedule-utils";
+
+// ── Enums ────────────────────────────────────────────────────────
+
+/** Ordered user roles — higher numeric value = more privilege. */
+export enum Role {
+  anon = 0,
+  user = 1,
+  teamUser = 2,
+  admin = 3,
+}
+
+/** Actions that can be gated per tab. */
+export enum AccessLevel {
+  view = "view",
+  signup = "signup",
+  admin = "admin",
+}
+
+// ── Types ────────────────────────────────────────────────────────
+
+/** Maps each access level to the minimum Role required. */
+export type TabPermissions = Record<AccessLevel, Role>;
+
+export type SessionPillColor = "gray" | "emerald" | "indigo" | "amber";
+
+// ── Raw config interfaces (authored in sports-config) ────────────
+
+export interface ResponseTableEntry {
+  time: string;
+  playerCap: number;
+  description?: string;
+  filterColumn?: { header: string; value: string };
+  hiddenColumns?: string[];
+}
+
+export interface ResponseTableConfig {
+  sheetTab: string;
+  columns: FormResponseColumn[];
+  sessions: ResponseTableEntry[];
+}
+
+export interface SessionTab {
+  value: string;
+  label: string;
+  /** Per-tab access control. Omitted keys fall back to defaults during resolution. */
+  permissions?: Partial<TabPermissions>;
+  /** Default prefix for session titles */
+  defaultTitlePrefix?: string;
+  /** Color token used for session type pills. */
+  sessionPillColor?: SessionPillColor;
+}
+
+export interface AdminTabMeta {
+  id: string;
+  label: string;
+  /** Lucide icon name (must be mapped in admin-sidebar) */
+  iconName: string;
+}
+
+export interface SportConfig {
+  id: Sport;
+  emoji: string;
+  name: string;
+  type: string;
+  location: {
+    name: string;
+    address: string;
+    mapsLink?: string;
+  };
+  day: string;
+  organizers: string;
+  waiverLink?: string;
+  notes: string[];
+  responseTable?: ResponseTableConfig;
+  multiSession?: boolean;
+  description?: string;
+  tabs?: SessionTab[];
+  defaultTab?: string;
+  authEnabled?: boolean;
+  /** Extra sport-specific tabs to show in the admin sidebar. */
+  adminTabs?: AdminTabMeta[];
+}
+
+// ── Resolved config interfaces (all defaults applied) ────────────
+
+/** A session tab with all permissions fully resolved — no Partials. */
+export interface ResolvedSessionTab extends Omit<SessionTab, "permissions"> {
+  permissions: TabPermissions;
+}
+
+/** A sport config with all tab permissions resolved and computed flags. */
+export interface ResolvedSportConfig extends Omit<SportConfig, "tabs"> {
+  tabs: ResolvedSessionTab[];
+  /** True if any tab requires a higher signup role than the default. */
+  hasRestrictedAccess: boolean;
+}

--- a/config/config-interfaces.ts
+++ b/config/config-interfaces.ts
@@ -10,11 +10,19 @@ export enum Role {
   admin = 3,
 }
 
-/** Actions that can be gated per tab. */
+/** Access level actions that can be gated per tab. */
 export enum AccessLevel {
   view = "view",
   signup = "signup",
   admin = "admin",
+}
+
+/** Session type pill colors. */
+export enum PillColor {
+  gray = "gray",
+  emerald = "emerald",
+  indigo = "indigo",
+  amber = "amber",
 }
 
 // ── Types ────────────────────────────────────────────────────────
@@ -22,7 +30,11 @@ export enum AccessLevel {
 /** Maps each access level to the minimum Role required. */
 export type TabPermissions = Record<AccessLevel, Role>;
 
-export type SessionPillColor = "gray" | "emerald" | "indigo" | "amber";
+/** Default values applied to every tab during resolution. */
+export interface TabDefaults {
+  permissions: TabPermissions;
+  sessionPillColor: PillColor;
+}
 
 // ── Raw config interfaces (authored in sports-config) ────────────
 
@@ -48,7 +60,7 @@ export interface SessionTab {
   /** Default prefix for session titles */
   defaultTitlePrefix?: string;
   /** Color token used for session type pills. */
-  sessionPillColor?: SessionPillColor;
+  sessionPillColor?: PillColor;
 }
 
 export interface AdminTabMeta {
@@ -84,9 +96,10 @@ export interface SportConfig {
 
 // ── Resolved config interfaces (all defaults applied) ────────────
 
-/** A session tab with all permissions fully resolved — no Partials. */
-export interface ResolvedSessionTab extends Omit<SessionTab, "permissions"> {
+/** A session tab with all defaults fully resolved — no optionals for defaulted fields. */
+export interface ResolvedSessionTab extends Omit<SessionTab, "permissions" | "sessionPillColor"> {
   permissions: TabPermissions;
+  sessionPillColor: PillColor;
 }
 
 /** A sport config with all tab permissions resolved and computed flags. */

--- a/config/config-resolver.ts
+++ b/config/config-resolver.ts
@@ -1,0 +1,42 @@
+import {
+  AccessLevel,
+  Role,
+  type SportConfig,
+  type ResolvedSessionTab,
+  type ResolvedSportConfig,
+  type TabPermissions,
+} from "./config-interfaces";
+import { SPORT_DEFAULTS, sportsConfig } from "./sports-config";
+
+// Re-export everything consumers need from a single entry point
+export * from "./config-interfaces";
+
+const defaults: TabPermissions = SPORT_DEFAULTS.tab.permissions;
+
+// ── Resolution ──────────────────────────────────────────────────
+
+/** Resolve a raw SportConfig into a ResolvedSportConfig with all defaults applied. */
+export function resolveSportConfig(config: SportConfig): ResolvedSportConfig {
+  const tabs: ResolvedSessionTab[] = (config.tabs ?? []).map((t) => ({
+    ...t,
+    permissions: { ...defaults, ...t.permissions },
+  }));
+  return {
+    ...config,
+    tabs,
+    hasRestrictedAccess: tabs.some(
+      (t) => t.permissions[AccessLevel.signup] > Role.user,
+    ),
+  };
+}
+
+/** Look up the resolved tab for a session type. Falls back to default permissions. */
+export function getResolvedTab(config: ResolvedSportConfig, sessionType: string): ResolvedSessionTab {
+  return config.tabs.find((t) => t.value === sessionType)
+    ?? { value: sessionType, label: sessionType, permissions: defaults };
+}
+
+/** Pre-resolved configs with all tab defaults applied. */
+export const resolvedSportsConfig: Record<string, ResolvedSportConfig> = Object.fromEntries(
+  Object.entries(sportsConfig).map(([key, config]) => [key, resolveSportConfig(config)]),
+);

--- a/config/config-resolver.ts
+++ b/config/config-resolver.ts
@@ -1,42 +1,85 @@
+/**
+ * Single entry point for all sport config consumers.
+ * Import from here — never directly from sports-config or config-interfaces.
+ * Use `resolvedSportsConfig[sport]` for fully resolved config with all defaults applied.
+ */
+
 import {
   AccessLevel,
-  Role,
   type SportConfig,
   type ResolvedSessionTab,
   type ResolvedSportConfig,
-  type TabPermissions,
 } from "./config-interfaces";
 import { SPORT_DEFAULTS, sportsConfig } from "./sports-config";
 
 // Re-export everything consumers need from a single entry point
 export * from "./config-interfaces";
 
-const defaults: TabPermissions = SPORT_DEFAULTS.tab.permissions;
+/**
+ * Recursively merges `defaults` under `overrides`. Nested plain objects are
+ * merged key-by-key so partial overrides (e.g. a tab that only sets
+ * `{ signup: Role.teamUser }`) keep all other default keys intact.
+ * Primitives and arrays in overrides replace defaults outright.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function deepMerge(defaults: Record<string, any>, overrides: Record<string, any>): Record<string, any> {
+  const result = { ...defaults };
+  for (const key of Object.keys(overrides)) {
+    const dVal = defaults[key];
+    const oVal = overrides[key];
+    if (dVal && oVal && typeof dVal === "object" && typeof oVal === "object" && !Array.isArray(dVal)) {
+      result[key] = deepMerge(dVal, oVal);
+    } else if (oVal !== undefined) {
+      result[key] = oVal;
+    }
+  }
+  return result;
+}
 
 // ── Resolution ──────────────────────────────────────────────────
 
-/** Resolve a raw SportConfig into a ResolvedSportConfig with all defaults applied. */
+/**
+ * Builds a fully resolved sport config from a raw one.
+ * Merges SPORT_DEFAULTS at the sport level, then merges tab-level defaults
+ * into each tab, so configs only need to declare overrides.
+ * Also computes derived flags like `hasRestrictedAccess`.
+ */
 export function resolveSportConfig(config: SportConfig): ResolvedSportConfig {
-  const tabs: ResolvedSessionTab[] = (config.tabs ?? []).map((t) => ({
-    ...t,
-    permissions: { ...defaults, ...t.permissions },
-  }));
+  // 1. Merge top-level sport defaults (authEnabled, etc.) under the raw config
+  const merged = deepMerge(SPORT_DEFAULTS, config);
+
+  // 2. Resolve each tab by merging tab defaults under it
+  const tabs: ResolvedSessionTab[] = (config.tabs ?? []).map((t) =>
+    deepMerge(SPORT_DEFAULTS.tab, t) as ResolvedSessionTab,
+  );
+
+  // 3. Compute derived flags
   return {
-    ...config,
+    ...merged,
     tabs,
     hasRestrictedAccess: tabs.some(
-      (t) => t.permissions[AccessLevel.signup] > Role.user,
+      (t) => t.permissions[AccessLevel.signup] > SPORT_DEFAULTS.tab.permissions[AccessLevel.signup],
     ),
-  };
+  } as ResolvedSportConfig;
 }
 
-/** Look up the resolved tab for a session type. Falls back to default permissions. */
+// ── Convenience helpers ─────────────────────────────────────────
+// Thin wrappers over resolved data that save consumers from duplicating
+// common lookups or fallback logic. No business rules live here — just
+// ergonomic shortcuts so call sites stay concise.
+
+/**
+ * Finds the resolved tab matching a session type. Used by consumers that
+ * have a session record and need its permissions/label/color without
+ * searching `config.tabs` and duplicating the fallback to defaults
+ * for unknown session types.
+ */
 export function getResolvedTab(config: ResolvedSportConfig, sessionType: string): ResolvedSessionTab {
   return config.tabs.find((t) => t.value === sessionType)
-    ?? { value: sessionType, label: sessionType, permissions: defaults };
+    ?? { value: sessionType, label: sessionType, ...SPORT_DEFAULTS.tab };
 }
 
-/** Pre-resolved configs with all tab defaults applied. */
+/** Pre-resolved configs keyed by sport slug. Consumers import this instead of raw sportsConfig. */
 export const resolvedSportsConfig: Record<string, ResolvedSportConfig> = Object.fromEntries(
   Object.entries(sportsConfig).map(([key, config]) => [key, resolveSportConfig(config)]),
 );

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -1,116 +1,19 @@
-import { Sport, FormResponseColumn } from "@/lib/schedule-utils";
+import { AccessLevel, Role, type SportConfig, type TabPermissions } from "./config-interfaces";
 
-// ── Enums ────────────────────────────────────────────────────────
+// ── Defaults ─────────────────────────────────────────────────────
 
-/** Ordered user roles — higher numeric value = more privilege. */
-export enum Role {
-  anon = 0,
-  user = 1,
-  teamUser = 2,
-  admin = 3,
-}
+export const SPORT_DEFAULTS = {
+  authEnabled: false,
+  tab: {
+    permissions: {
+      [AccessLevel.view]: Role.anon,
+      [AccessLevel.signup]: Role.user,
+      [AccessLevel.admin]: Role.admin,
+    } satisfies TabPermissions,
+  },
+} as const;
 
-/** Actions that can be gated per tab. */
-export enum AccessLevel {
-  view = "view",
-  signup = "signup",
-  admin = "admin",
-}
-
-/** Maps each access level to the minimum Role required. */
-export type TabPermissions = Record<AccessLevel, Role>;
-
-export const DEFAULT_PERMISSIONS: TabPermissions = {
-  [AccessLevel.view]: Role.anon,
-  [AccessLevel.signup]: Role.user,
-  [AccessLevel.admin]: Role.admin,
-};
-
-// ── Config interfaces ───────────────────────────────────────────
-
-export interface ResponseTableEntry {
-  time: string;
-  playerCap: number;
-  description?: string;
-  filterColumn?: { header: string; value: string };
-  hiddenColumns?: string[];
-}
-
-export interface ResponseTableConfig {
-  sheetTab: string;
-  columns: FormResponseColumn[];
-  sessions: ResponseTableEntry[];
-}
-
-export type SessionPillColor = "gray" | "emerald" | "indigo" | "amber";
-
-export interface SessionTab {
-  value: string;
-  label: string;
-  /** Per-tab access control. Omitted keys fall back to DEFAULT_PERMISSIONS. */
-  permissions?: Partial<TabPermissions>;
-  /** Default prefix for session titles */
-  defaultTitlePrefix?: string;
-  /** Color token used for session type pills. */
-  sessionPillColor?: SessionPillColor;
-}
-
-export interface AdminTabMeta {
-  id: string;
-  label: string;
-  /** Lucide icon name (must be mapped in admin-sidebar) */
-  iconName: string;
-}
-
-export interface SportConfig {
-  id: Sport;
-  emoji: string;
-  name: string;
-  type: string;
-  location: {
-    name: string;
-    address: string;
-    mapsLink?: string;
-  };
-  day: string;
-  organizers: string;
-  waiverLink?: string;
-  notes: string[];
-  responseTable?: ResponseTableConfig;
-  multiSession?: boolean;
-  description?: string;
-  tabs?: SessionTab[];
-  defaultTab?: string;
-  authEnabled?: boolean;
-  /** Extra sport-specific tabs to show in the admin sidebar. */
-  adminTabs?: AdminTabMeta[];
-}
-
-/** Resolve the full permissions for a given session type, merging with defaults. */
-export function getTabPermissions(config: SportConfig | undefined, sessionType: string): TabPermissions {
-  const tab = config?.tabs?.find((t) => t.value === sessionType);
-  return { ...DEFAULT_PERMISSIONS, ...tab?.permissions };
-}
-
-/** Returns true if the given session type belongs to a restricted-access tab. */
-export function isRestrictedSessionType(config: SportConfig | undefined, sessionType: string): boolean {
-  return getTabPermissions(config, sessionType)[AccessLevel.signup] >= Role.teamUser;
-}
-
-/** Returns true if the sport has any tab with restricted access. */
-export function hasRestrictedAccess(config: SportConfig | undefined): boolean {
-  return config?.tabs?.some((t) => getTabPermissions(config, t.value)[AccessLevel.signup] >= Role.teamUser) ?? false;
-}
-
-/** Look up the tab label for a session type from sportsConfig. */
-export function getSessionTypeLabel(config: SportConfig | undefined, sessionType: string): string {
-  return config?.tabs?.find((t) => t.value === sessionType)?.label ?? sessionType;
-}
-
-/** Look up the default title prefix for a session type from sportsConfig. */
-export function getDefaultTitlePrefix(config: SportConfig | undefined, sessionType: string): string | undefined {
-  return config?.tabs?.find((t) => t.value === sessionType)?.defaultTitlePrefix;
-}
+// ── Sport configurations ─────────────────────────────────────────
 
 export const sportsConfig: Record<string, SportConfig> = {
   basketball: {
@@ -234,14 +137,14 @@ export const sportsConfig: Record<string, SportConfig> = {
       {
         value: "scheduled_game",
         label: "Scheduled Games",
-        permissions: { [AccessLevel.view]: Role.user, [AccessLevel.signup]: Role.teamUser },
+        permissions: { [AccessLevel.view]: Role.teamUser, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Game",
         sessionPillColor: "indigo",
       },
       {
         value: "umpiring",
         label: "Umpiring",
-        permissions: { [AccessLevel.view]: Role.user, [AccessLevel.signup]: Role.teamUser },
+        permissions: { [AccessLevel.view]: Role.teamUser, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Umpiring",
         sessionPillColor: "amber",
       },

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -1,4 +1,9 @@
-import { AccessLevel, Role, type SportConfig, type TabPermissions } from "./config-interfaces";
+/**
+ * Raw sport config data and defaults. Internal to config/ — do not import
+ * directly. Use config-resolver.ts as the single consumer entry point.
+ */
+
+import { AccessLevel, Role, PillColor, type SportConfig, type TabDefaults } from "./config-interfaces";
 
 // ── Defaults ─────────────────────────────────────────────────────
 
@@ -9,8 +14,9 @@ export const SPORT_DEFAULTS = {
       [AccessLevel.view]: Role.anon,
       [AccessLevel.signup]: Role.user,
       [AccessLevel.admin]: Role.admin,
-    } satisfies TabPermissions,
-  },
+    },
+    sessionPillColor: PillColor.gray,
+  } satisfies TabDefaults,
 } as const;
 
 // ── Sport configurations ─────────────────────────────────────────
@@ -132,21 +138,21 @@ export const sportsConfig: Record<string, SportConfig> = {
         value: "drop_in_practice",
         label: "Drop-in Practice",
         defaultTitlePrefix: "Practice",
-        sessionPillColor: "emerald",
+        sessionPillColor: PillColor.emerald,
       },
       {
         value: "scheduled_game",
         label: "Scheduled Games",
         permissions: { [AccessLevel.view]: Role.teamUser, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Game",
-        sessionPillColor: "indigo",
+        sessionPillColor: PillColor.indigo,
       },
       {
         value: "umpiring",
         label: "Umpiring",
         permissions: { [AccessLevel.view]: Role.teamUser, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Umpiring",
-        sessionPillColor: "amber",
+        sessionPillColor: PillColor.amber,
       },
     ],
   },

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -1,5 +1,33 @@
 import { Sport, FormResponseColumn } from "@/lib/schedule-utils";
 
+// ── Enums ────────────────────────────────────────────────────────
+
+/** Ordered user roles — higher numeric value = more privilege. */
+export enum Role {
+  anon = 0,
+  user = 1,
+  teamUser = 2,
+  admin = 3,
+}
+
+/** Actions that can be gated per tab. */
+export enum AccessLevel {
+  view = "view",
+  signup = "signup",
+  admin = "admin",
+}
+
+/** Maps each access level to the minimum Role required. */
+export type TabPermissions = Record<AccessLevel, Role>;
+
+export const DEFAULT_PERMISSIONS: TabPermissions = {
+  [AccessLevel.view]: Role.anon,
+  [AccessLevel.signup]: Role.user,
+  [AccessLevel.admin]: Role.admin,
+};
+
+// ── Config interfaces ───────────────────────────────────────────
+
 export interface ResponseTableEntry {
   time: string;
   playerCap: number;
@@ -19,7 +47,8 @@ export type SessionPillColor = "gray" | "emerald" | "indigo" | "amber";
 export interface SessionTab {
   value: string;
   label: string;
-  restrictedAccess?: boolean;
+  /** Per-tab access control. Omitted keys fall back to DEFAULT_PERMISSIONS. */
+  permissions?: Partial<TabPermissions>;
   /** Default prefix for session titles */
   defaultTitlePrefix?: string;
   /** Color token used for session type pills. */
@@ -57,14 +86,20 @@ export interface SportConfig {
   adminTabs?: AdminTabMeta[];
 }
 
+/** Resolve the full permissions for a given session type, merging with defaults. */
+export function getTabPermissions(config: SportConfig | undefined, sessionType: string): TabPermissions {
+  const tab = config?.tabs?.find((t) => t.value === sessionType);
+  return { ...DEFAULT_PERMISSIONS, ...tab?.permissions };
+}
+
 /** Returns true if the given session type belongs to a restricted-access tab. */
 export function isRestrictedSessionType(config: SportConfig | undefined, sessionType: string): boolean {
-  return config?.tabs?.some((t) => t.value === sessionType && t.restrictedAccess) ?? false;
+  return getTabPermissions(config, sessionType)[AccessLevel.signup] >= Role.teamUser;
 }
 
 /** Returns true if the sport has any tab with restricted access. */
 export function hasRestrictedAccess(config: SportConfig | undefined): boolean {
-  return config?.tabs?.some((t) => t.restrictedAccess) ?? false;
+  return config?.tabs?.some((t) => getTabPermissions(config, t.value)[AccessLevel.signup] >= Role.teamUser) ?? false;
 }
 
 /** Look up the tab label for a session type from sportsConfig. */
@@ -199,14 +234,14 @@ export const sportsConfig: Record<string, SportConfig> = {
       {
         value: "scheduled_game",
         label: "Scheduled Games",
-        restrictedAccess: true,
+        permissions: { [AccessLevel.view]: Role.user, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Game",
         sessionPillColor: "indigo",
       },
       {
         value: "umpiring",
         label: "Umpiring",
-        restrictedAccess: true,
+        permissions: { [AccessLevel.view]: Role.user, [AccessLevel.signup]: Role.teamUser },
         defaultTitlePrefix: "Umpiring",
         sessionPillColor: "amber",
       },

--- a/lib/actions/signups.ts
+++ b/lib/actions/signups.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { promoteOneFromWaitlist, resolveSignupStatus } from "@/lib/signup-capacity";
-import { sportsConfig, isRestrictedSessionType } from "@/config/sports-config";
+import { resolvedSportsConfig, getResolvedTab, AccessLevel } from "@/config/config-resolver";
 import { getUserSportRole, getUser, requireSportAdmin } from "@/lib/supabase/user";
 
 export interface SignupPlacement {
@@ -81,14 +81,11 @@ export async function signUpForSession(
   if (!session) return { error: "Session not found" };
 
   const sport = session.sport;
-  const sportConfig = sportsConfig[sport];
+  const tab = getResolvedTab(resolvedSportsConfig[sport], session.session_type);
 
-  if (isRestrictedSessionType(sportConfig, session.session_type)) {
-    const { isTeamMember } = await getUserSportRole(supabase, user.id, sport);
-
-    if (!isTeamMember) {
-      return { error: "Only team members can sign up for scheduled games" };
-    }
+  const { role } = await getUserSportRole(supabase, user.id, sport);
+  if (role < tab.permissions[AccessLevel.signup]) {
+    return { error: "You don't have permission to sign up for this session" };
   }
 
   const { data: existingSignup } = await supabase
@@ -222,13 +219,11 @@ export async function declineSession(
   if (!session) return { error: "Session not found" };
 
   const sport = session.sport;
-  const sportConfig = sportsConfig[sport];
+  const tab = getResolvedTab(resolvedSportsConfig[sport], session.session_type);
 
-  if (isRestrictedSessionType(sportConfig, session.session_type)) {
-    const { isTeamMember } = await getUserSportRole(supabase, user.id, sport);
-    if (!isTeamMember) {
-      return { error: "Only team members can respond to scheduled games" };
-    }
+  const { role } = await getUserSportRole(supabase, user.id, sport);
+  if (role < tab.permissions[AccessLevel.signup]) {
+    return { error: "You don't have permission to respond to this session" };
   }
 
   const { data: existingSignup } = await supabase

--- a/lib/session-type-pill.ts
+++ b/lib/session-type-pill.ts
@@ -1,4 +1,4 @@
-import type { SessionPillColor, SportConfig } from "@/config/sports-config";
+import type { SessionPillColor, SportConfig } from "@/config/config-resolver";
 
 const DEFAULT_SESSION_PILL_COLOR: SessionPillColor = "gray";
 

--- a/lib/session-type-pill.ts
+++ b/lib/session-type-pill.ts
@@ -1,24 +1,23 @@
-import type { SessionPillColor, SportConfig } from "@/config/config-resolver";
+import { PillColor, type ResolvedSportConfig } from "@/config/config-resolver";
 
-const DEFAULT_SESSION_PILL_COLOR: SessionPillColor = "gray";
-
-const SESSION_PILL_COLOR_CLASSES: Record<SessionPillColor, string> = {
-  gray: "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-100",
-  emerald:
+const SESSION_PILL_COLOR_CLASSES: Record<PillColor, string> = {
+  [PillColor.gray]:
+    "border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-100",
+  [PillColor.emerald]:
     "border-emerald-200 bg-emerald-50 text-emerald-900 hover:bg-emerald-50",
-  indigo:
+  [PillColor.indigo]:
     "border-indigo-200 bg-indigo-50 text-indigo-900 hover:bg-indigo-50",
-  amber:
+  [PillColor.amber]:
     "border-amber-200 bg-amber-50 text-amber-950 hover:bg-amber-50",
 };
 
 export function sessionTypePillClass(
-  config: SportConfig | undefined,
+  config: ResolvedSportConfig,
   sessionType: string,
 ): string {
   const color =
-    config?.tabs?.find((tab) => tab.value === sessionType)?.sessionPillColor ??
-    DEFAULT_SESSION_PILL_COLOR;
+    config.tabs.find((tab) => tab.value === sessionType)?.sessionPillColor ??
+    PillColor.gray;
 
   return SESSION_PILL_COLOR_CLASSES[color];
 }

--- a/lib/supabase/user.ts
+++ b/lib/supabase/user.ts
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import type { SupabaseClient, User } from "@supabase/supabase-js";
-import { sportsConfig, hasRestrictedAccess, Role } from "@/config/sports-config";
+import { resolvedSportsConfig, Role, AccessLevel } from "@/config/config-resolver";
 
 /**
  * Reads the authenticated user forwarded by middleware via the
@@ -17,15 +17,20 @@ export async function getUser(): Promise<User | null> {
     }
 }
 
-/** Resolves the current user's Role from auth + role flags. */
-export function getUserRole(
-    user: User | null,
-    isTeamMember: boolean,
-    isAdmin: boolean,
-): Role {
+/**
+ * Resolves the highest Role a user qualifies for from a set of boolean qualifiers.
+ * The qualifiers record maps each elevated Role (above `user`) to whether the
+ * user satisfies it. Roles are checked highest-first so the most privileged match wins.
+ */
+export function getUserRole(user: User | null, qualifiers: Partial<Record<Role, boolean>>): Role {
     if (!user) return Role.anon;
-    if (isAdmin) return Role.admin;
-    if (isTeamMember) return Role.teamUser;
+    // Walk roles from highest to lowest (skip anon/user — they're the floor)
+    const elevatedRoles = Object.values(Role)
+        .filter((v): v is Role => typeof v === "number" && v > Role.user)
+        .sort((a, b) => b - a);
+    for (const role of elevatedRoles) {
+        if (qualifiers[role]) return role;
+    }
     return Role.user;
 }
 
@@ -44,7 +49,7 @@ export async function getUserSportRole(
     userId: string,
     sport: string,
 ): Promise<UserSportRole> {
-    const sportConfig = sportsConfig[sport];
+    const sportConfig = resolvedSportsConfig[sport];
 
     const [{ data: profile }, { data: sportRole }] = await Promise.all([
         supabase.from("profiles").select("role").eq("id", userId).single(),
@@ -56,13 +61,23 @@ export async function getUserSportRole(
             .single(),
     ]);
 
+    // TODO: Revamp DB schema so role resolution maps directly from a single
+    // `role` column (matching the Role enum) instead of combining separate
+    // `profiles.role`, `sport_roles.role`, and `is_team_member` columns.
     const isAdmin =
         profile?.role === "admin" || sportRole?.role === "admin";
-    const isTeamMember = hasRestrictedAccess(sportConfig)
+    const isTeamMember = sportConfig?.hasRestrictedAccess
         ? isAdmin || !!sportRole?.is_team_member
         : true;
 
-    return { role: getUserRole({ id: userId } as User, isTeamMember, isAdmin), isAdmin, isTeamMember };
+    return {
+        role: getUserRole({ id: userId } as User, {
+            [Role.admin]: isAdmin,
+            [Role.teamUser]: isTeamMember,
+        }),
+        isAdmin,
+        isTeamMember,
+    };
 }
 
 /**

--- a/lib/supabase/user.ts
+++ b/lib/supabase/user.ts
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import type { SupabaseClient, User } from "@supabase/supabase-js";
-import { sportsConfig, hasRestrictedAccess } from "@/config/sports-config";
+import { sportsConfig, hasRestrictedAccess, Role } from "@/config/sports-config";
 
 /**
  * Reads the authenticated user forwarded by middleware via the
@@ -17,7 +17,20 @@ export async function getUser(): Promise<User | null> {
     }
 }
 
+/** Resolves the current user's Role from auth + role flags. */
+export function getUserRole(
+    user: User | null,
+    isTeamMember: boolean,
+    isAdmin: boolean,
+): Role {
+    if (!user) return Role.anon;
+    if (isAdmin) return Role.admin;
+    if (isTeamMember) return Role.teamUser;
+    return Role.user;
+}
+
 export interface UserSportRole {
+    role: Role;
     isAdmin: boolean;
     isTeamMember: boolean;
 }
@@ -49,7 +62,7 @@ export async function getUserSportRole(
         ? isAdmin || !!sportRole?.is_team_member
         : true;
 
-    return { isAdmin, isTeamMember };
+    return { role: getUserRole({ id: userId } as User, isTeamMember, isAdmin), isAdmin, isTeamMember };
 }
 
 /**
@@ -64,8 +77,8 @@ export async function requireSportAdmin(
     const user = await getUser();
     if (!user) return { success: false, error: "Not authenticated" };
 
-    const { isAdmin } = await getUserSportRole(supabase, user.id, sport);
-    if (!isAdmin) return { success: false, error: "Not authorized" };
+    const { role } = await getUserSportRole(supabase, user.id, sport);
+    if (role < Role.admin) return { success: false, error: "Not authorized" };
 
     return { success: true, user };
 }

--- a/supabase/migrations/20260515222236_open_sessions_to_public_reads.sql
+++ b/supabase/migrations/20260515222236_open_sessions_to_public_reads.sql
@@ -1,0 +1,9 @@
+-- Allow anonymous (public) reads on sessions.
+-- Sessions contain only public event info (title, date, time, location).
+-- Signups remain gated by auth.uid() is not null.
+
+drop policy if exists "sessions_read" on public.sessions;
+
+create policy "sessions_read"
+  on public.sessions for select
+  using (true);


### PR DESCRIPTION
Refactored permissions architecture to be declarative, config-driven, and extensible:

Config structure: Split into 3 modules — interfaces (types/enums), sports-config (raw config + defaults), resolver (single entry point)
All consumers import from resolver

Access controls defined in sport-config; signup badges/count/timer hidden when inaccessible

Simplified API: [getResolvedTab()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now 2 args instead of 3; no raw [sportsConfig](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) or [SPORT_DEFAULTS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) exposure

Improves maintainability — single source of truth for permissions, no hardcoding, easy to add new roles/levels via enum iteration.


@daniel-yili-ye could you do the schema migration? I have included the file but I have not modified the DB.