### PR TITLE
fix: resolve hydration mismatches in session dialog and local timestamp

### DIFF
--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
   CalendarDays,
   Clock,
   MapPin,
-  Pencil,
   UserStar,
 } from "lucide-react";
 import PageHeader from "@/components/sports/page-header";
@@ -24,7 +23,7 @@ import { isSignupOpen } from "@/lib/signup-capacity";
 import SessionSignupsTable from "@/components/sports/session-signups-table";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
-import { Button } from "@/components/ui/button";
+
 import { resolvedSportsConfig, getResolvedTab, Role, AccessLevel } from "@/config/config-resolver";
 import { formatDate, formatTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -187,12 +186,6 @@ export default async function SessionDetailPage({
                 <SessionDialog
                   sport={sport}
                   session={session}
-                  trigger={
-                    <Button variant="outline" size="sm">
-                      <Pencil className="h-4 w-4 mr-1.5" />
-                      Edit
-                    </Button>
-                  }
                 />
                 <CancelSessionButton sport={sport} sessionId={session.id} variant="full" />
               </div>

--- a/components/sports/local-timestamp.tsx
+++ b/components/sports/local-timestamp.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { formatTimestamp, formatDateTimeWithWeekday } from "@/lib/format";
 
 interface LocalTimestampProps {
@@ -8,9 +9,13 @@ interface LocalTimestampProps {
 }
 
 export default function LocalTimestamp({ date, weekday }: LocalTimestampProps) {
-    const formatted = weekday
-        ? formatDateTimeWithWeekday(date, weekday)
-        : formatTimestamp(date);
+    const [formatted, setFormatted] = useState("");
+
+    useEffect(() => {
+        setFormatted(
+            weekday ? formatDateTimeWithWeekday(date, weekday) : formatTimestamp(date),
+        );
+    }, [date, weekday]);
 
     return <time dateTime={date}>{formatted}</time>;
 }

--- a/components/sports/session-dialog.tsx
+++ b/components/sports/session-dialog.tsx
@@ -9,13 +9,15 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Pencil } from "lucide-react";
 import SessionForm from "@/components/sports/session-form";
 import type { SportSession } from "@/lib/supabase/types";
 
 interface SessionDialogProps {
   sport: string;
   session?: SportSession;
-  trigger: ReactNode;
+  trigger?: ReactNode;
 }
 
 export default function SessionDialog({ sport, session, trigger }: SessionDialogProps) {
@@ -24,7 +26,14 @@ export default function SessionDialog({ sport, session, trigger }: SessionDialog
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button variant="outline" size="sm">
+            <Pencil className="h-4 w-4 mr-1.5" />
+            {isEdit ? "Edit" : "Create"}
+          </Button>
+        )}
+      </DialogTrigger>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg [&_form]:min-w-0 [&_input]:min-w-0">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit Session" : "Create Session"}</DialogTitle>


### PR DESCRIPTION
- Fix Edit Button not showing up sometimes: make SessionDialog render its own trigger button internally to avoid passing ReactNode across server/client boundary
- Defer locale-dependent formatting in LocalTimestamp to client-side useEffect to prevent server/client toLocaleString differences
- Remove unused Button/Pencil imports from session detail page