### PR TITLE
fix: permission-based access gating and UX improvements

### DIFF
--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -161,21 +161,61 @@ async function SportSessionsContent({
 
   const hasHiddenSessions = sessionsWithCounts.length > viewableSessions.length;
 
-  // Find the highest view permission among restricted tabs for the "All" banner
-  const highestRestrictedViewRole = hasHiddenSessions
-    ? Math.max(...configTabs.filter((t) => userRole < t.permissions[AccessLevel.view]).map((t) => t.permissions[AccessLevel.view]))
+  // Determine the "All" tab banner based on which tabs are restricted
+  const hiddenTabs = configTabs.filter((t) => userRole < t.permissions[AccessLevel.view]);
+  const lowestHiddenRole = hasHiddenSessions
+    ? Math.min(...hiddenTabs.map((t) => t.permissions[AccessLevel.view])) as Role
     : Role.anon;
+  const hasViewableSessions = viewableSessions.length > 0;
 
-  const allGateBanner = hasHiddenSessions
-    ? getAccessGateBanner({
-      userId,
-      userRole,
-      requiredViewRole: highestRestrictedViewRole as Role,
-      accessRequestStatus,
-      sport,
-      label: "all sessions",
-    })
-    : null;
+  const allGateBanner = (() => {
+    if (!hasHiddenSessions) return null;
+
+    // Signed-in user lacking team access → show request banner
+    if (userId) {
+      return (
+        <TeamAccessBanner
+          requestStatus={accessRequestStatus}
+          sport={sport}
+        />
+      );
+    }
+
+    // Anon user — wording depends on whether they can already see some sessions
+    if (hasViewableSessions) {
+      // They can see some but not all
+      return (
+        <SignInToSignupBanner
+          title={
+            lowestHiddenRole >= Role.teamUser
+              ? "Some sessions require team access"
+              : "Sign in to view more sessions"
+          }
+          message={
+            lowestHiddenRole >= Role.teamUser
+              ? "Sign in and request team access to view all sessions."
+              : "Sign in with your Google account to view all sessions."
+          }
+        />
+      );
+    }
+
+    // They can't see anything
+    return (
+      <SignInToSignupBanner
+        title={
+          lowestHiddenRole >= Role.teamUser
+            ? "Team members only"
+            : "Sign in to view sessions"
+        }
+        message={
+          lowestHiddenRole >= Role.teamUser
+            ? "Sign in and request team access to view and sign up for sessions."
+            : "Sign in with your Google account to view and sign up for sessions."
+        }
+      />
+    );
+  })();
 
   const allOption = showAll
     ? {

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -11,7 +11,57 @@ import AdminButton from "@/components/sports/admin-button";
 import { resolvedSportsConfig, Role, AccessLevel } from "@/config/config-resolver";
 import { LoadingContent } from "@/components/sports/loading-content";
 import { getUpcomingSessions, getUserAccessRequestStatus, getUserSignupStatuses } from "@/lib/get-data";
-import type { SignupStatus } from "@/lib/supabase/types";
+import type { SignupStatus, AccessRequestStatus } from "@/lib/supabase/types";
+
+/**
+ * Returns the appropriate access gate banner for a tab based on user state.
+ * - Anon user → SignInToSignupBanner (with contextual text)
+ * - Signed-in user lacking access → TeamAccessBanner (with request button)
+ * - User has access → null
+ */
+function getAccessGateBanner({
+  userId,
+  userRole,
+  requiredViewRole,
+  accessRequestStatus,
+  sport,
+  label,
+}: {
+  userId: string | null;
+  userRole: Role;
+  requiredViewRole: Role;
+  accessRequestStatus: AccessRequestStatus | null;
+  sport: string;
+  label: string;
+}) {
+  if (userRole >= requiredViewRole) return null;
+
+  // Anon user — needs to sign in
+  if (!userId) {
+    return (
+      <SignInToSignupBanner
+        title={
+          requiredViewRole >= Role.teamUser
+            ? "Team members only"
+            : `Sign in to view ${label}`
+        }
+        message={
+          requiredViewRole >= Role.teamUser
+            ? `Sign in and request team access to view and sign up for ${label}.`
+            : `Sign in with your Google account to view and sign up for ${label}.`
+        }
+      />
+    );
+  }
+
+  // Signed-in user lacking team access
+  return (
+    <TeamAccessBanner
+      requestStatus={accessRequestStatus}
+      sport={sport}
+    />
+  );
+}
 
 async function SportSessionsContent({
   sport,
@@ -38,37 +88,48 @@ async function SportSessionsContent({
   ]);
 
   const userRole = roleResult.role;
-  let accessRequestStatus: "pending" | "approved" | "rejected" | null = null;
 
-  const showTeamAccessBanner = !!userId && config.tabs.some((t) =>
-    userRole < t.permissions[AccessLevel.signup]
+  const needsAccessRequest = !!userId && config.tabs.some((t) =>
+    userRole < t.permissions[AccessLevel.view] || userRole < t.permissions[AccessLevel.signup]
   );
 
-  if (showTeamAccessBanner) {
-    accessRequestStatus = await getUserAccessRequestStatus(userId!, sport);
-  }
-
   const sessionIds = sessionsWithCounts.map((session) => session.id);
-  const userSignupStatusBySession = userId
-    ? await getUserSignupStatuses(userId, sessionIds)
-    : new Map<string, SignupStatus>();
+
+  const [accessRequestStatus, userSignupStatusBySession] = await Promise.all([
+    needsAccessRequest
+      ? getUserAccessRequestStatus(userId!, sport)
+      : Promise.resolve(null),
+    userId
+      ? getUserSignupStatuses(userId, sessionIds)
+      : Promise.resolve(new Map<string, SignupStatus>()),
+  ]);
 
   const sessionsByType = Object.groupBy(sessionsWithCounts, (s) => s.session_type);
 
   const configTabs = config.tabs ?? [];
   const showAll = configTabs.length > 1;
   const ALL_VALUE = "all";
-  const requiresSignIn = !!config.authEnabled && !userId;
 
   const typeOptions = configTabs.map((t) => {
     const sessions = sessionsByType[t.value] ?? [];
+    const canView = userRole >= t.permissions[AccessLevel.view];
+    const gateBanner = getAccessGateBanner({
+      userId,
+      userRole,
+      requiredViewRole: t.permissions[AccessLevel.view],
+      accessRequestStatus,
+      sport,
+      label: t.label.toLowerCase(),
+    });
 
     return {
       value: t.value,
       label: t.label,
       content: (
-        <>
-          {sessions.length > 0 ? (
+        <div className="space-y-4">
+          {gateBanner ? (
+            gateBanner
+          ) : sessions.length > 0 ? (
             <div className="grid gap-6 md:grid-cols-2">
               {sessions.map((session) => (
                 <SessionCard
@@ -83,25 +144,49 @@ async function SportSessionsContent({
                 />
               ))}
             </div>
-          ) : requiresSignIn ? null : (
+          ) : !canView ? null : (
             <p className="text-sm text-muted-foreground py-8 text-center">
               No upcoming {t.label.toLowerCase()}.
             </p>
           )}
-        </>
+        </div>
       ),
     };
   });
+
+  const viewableSessions = sessionsWithCounts.filter((session) => {
+    const tab = configTabs.find((t) => t.value === session.session_type);
+    return !tab || userRole >= tab.permissions[AccessLevel.view];
+  });
+
+  const hasHiddenSessions = sessionsWithCounts.length > viewableSessions.length;
+
+  // Find the highest view permission among restricted tabs for the "All" banner
+  const highestRestrictedViewRole = hasHiddenSessions
+    ? Math.max(...configTabs.filter((t) => userRole < t.permissions[AccessLevel.view]).map((t) => t.permissions[AccessLevel.view]))
+    : Role.anon;
+
+  const allGateBanner = hasHiddenSessions
+    ? getAccessGateBanner({
+      userId,
+      userRole,
+      requiredViewRole: highestRestrictedViewRole as Role,
+      accessRequestStatus,
+      sport,
+      label: "all sessions",
+    })
+    : null;
 
   const allOption = showAll
     ? {
       value: ALL_VALUE,
       label: "All",
       content: (
-        <>
-          {sessionsWithCounts.length > 0 ? (
+        <div className="space-y-4">
+          {allGateBanner}
+          {viewableSessions.length > 0 ? (
             <div className="grid gap-6 md:grid-cols-2">
-              {sessionsWithCounts.map((session) => (
+              {viewableSessions.map((session) => (
                 <SessionCard
                   key={session.id}
                   session={session}
@@ -114,12 +199,12 @@ async function SportSessionsContent({
                 />
               ))}
             </div>
-          ) : requiresSignIn ? null : (
+          ) : !hasHiddenSessions ? (
             <p className="text-sm text-muted-foreground py-8 text-center">
               No upcoming sessions.
             </p>
-          )}
-        </>
+          ) : null}
+        </div>
       ),
     }
     : null;
@@ -130,30 +215,17 @@ async function SportSessionsContent({
   const scrollSession = scrollTo ? sessionsWithCounts.find((s) => s.id === scrollTo) : null;
   const resolvedValue = tab ?? scrollSession?.session_type;
   const validValues = filterOptions.map((o) => o.value);
+  const fallback = config.defaultTab || (showAll ? ALL_VALUE : configTabs[0]?.value);
   const defaultValue =
-    validValues.find((v) => v === resolvedValue) ??
-    (showAll ? ALL_VALUE : config.defaultTab ?? configTabs[0]?.value);
-
-  const showSignInBanner =
-    !userId && !!config.authEnabled && config.hasRestrictedAccess;
+    validValues.find((v) => v === resolvedValue) ?? fallback;
 
   return (
     <div className="space-y-4">
-      {showTeamAccessBanner && (
-        <TeamAccessBanner
-          requestStatus={accessRequestStatus}
-          sport={sport}
-        />
-      )}
-      {showSignInBanner && (
-        <SignInToSignupBanner />
-      )}
       <SessionFilter
         defaultValue={defaultValue}
         options={filterOptions}
         scrollTo={scrollTo}
         sport={sport}
-        showFilters={!requiresSignIn}
       />
     </div>
   );

--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -102,18 +102,20 @@ async function SessionSignupsContent({
         )}
       </div>
 
-      <div className="space-y-2">
-        <AttendanceSection
-          sport={sport}
-          sessionId={sessionId}
-          signups={rawSignups}
-          teamMemberIds={teamMemberIds}
-          playerCap={playerCap}
-          currentUserId={userId}
-          viewData={viewData}
-          isAdmin={isAdmin}
-        />
-      </div>
+      {(canSignup || requestApproved) && (
+        <div className="space-y-2">
+          <AttendanceSection
+            sport={sport}
+            sessionId={sessionId}
+            signups={rawSignups}
+            teamMemberIds={teamMemberIds}
+            playerCap={playerCap}
+            currentUserId={userId}
+            viewData={viewData}
+            isAdmin={isAdmin}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/components/sports/auth-button.tsx
+++ b/components/sports/auth-button.tsx
@@ -41,7 +41,7 @@ export default function AuthButton({ user, sport }: AuthButtonProps) {
         onClick={handleSignIn}
       >
         <LogIn className="h-4 w-4" />
-        Sign in with Google
+        Sign in
       </Button>
     );
   }

--- a/components/sports/sign-in-to-signup-banner.tsx
+++ b/components/sports/sign-in-to-signup-banner.tsx
@@ -5,7 +5,15 @@ import { LogIn } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 
-export default function SignInToSignupBanner() {
+interface SignInToSignupBannerProps {
+  title?: string;
+  message?: string;
+}
+
+export default function SignInToSignupBanner({
+  title = "Sign in to view and sign up for sessions",
+  message = "Use your Google account to get started.",
+}: SignInToSignupBannerProps) {
   const pathname = usePathname();
 
   const handleSignIn = async () => {
@@ -21,10 +29,10 @@ export default function SignInToSignupBanner() {
   return (
     <div className="rounded-lg border border-status-info-border bg-status-info p-4">
       <p className="font-medium text-status-info-foreground">
-        Sign in to view and sign up for sessions
+        {title}
       </p>
       <p className="mt-1 text-sm text-status-info-foreground/80">
-        Use your Google account to get started.
+        {message}
       </p>
       <Button
         type="button"

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -148,7 +148,7 @@ export const sportsConfig: Record<string, SportConfig> = {
         label: "Drop-in Practice",
         defaultTitlePrefix: "Practice",
         sessionPillColor: PillColor.emerald,
-        permissions: { [AccessLevel.view]: Role.anon },
+        permissions: { [AccessLevel.view]: Role.user },
       },
       {
         value: "scheduled_game",

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -141,14 +141,14 @@ export const sportsConfig: Record<string, SportConfig> = {
       "Please contact the leaders if you have any questions.",
     ],
     description: "Join us for Drop-in Practices. Scheduled Games are only open to confirmed CCSA Team Members.",
-    defaultTab: "drop_in_practice",
+    defaultTab: "",
     tabs: [
       {
         value: "drop_in_practice",
         label: "Drop-in Practice",
         defaultTitlePrefix: "Practice",
         sessionPillColor: PillColor.emerald,
-        permissions: { [AccessLevel.view]: Role.user },
+        permissions: { [AccessLevel.view]: Role.anon },
       },
       {
         value: "scheduled_game",


### PR DESCRIPTION
## Summary

Fixes permission gating so anon/non-team users see appropriate access banners instead of restricted content, with contextual messaging that updates per tab.

## Changes

- **Per-tab view gating**: Sessions filtered by `AccessLevel.view` permission — anon users no longer see team-only sessions
- **Contextual banners**: `getAccessGateBanner()` helper shows `SignInToSignupBanner` for anon users or `TeamAccessBanner` (with request button) for signed-in users lacking access
- **"All" tab filtering**: Only shows sessions the user can view; displays appropriate banner when some are hidden
- **`defaultTab` honored**: Uses configured default tab over "All" when set
- **Session detail page**: Hides attendance section when user lacks signup access
- **Session card**: Clickable for anyone with view access
- **Auth button**: Renamed to "Sign in"
- **Dropdown menu**: Added `cursor-pointer`