### PR TITLE
feat: config-driven signup confirmation dialog for non-team-members

### DIFF
--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -24,7 +24,7 @@ import AttendanceSection from "@/components/sports/attendance-section";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
 
-import { resolvedSportsConfig, getResolvedTab, Role, AccessLevel } from "@/config/config-resolver";
+import { resolvedSportsConfig, getResolvedTab, Role, AccessLevel, type SignupConfirmationDialog } from "@/config/config-resolver";
 import { formatDate, formatTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { sessionTypePillClass } from "@/lib/session-type-pill";
@@ -49,6 +49,7 @@ async function SessionSignupsContent({
   playerCap,
   viewData,
   isAdmin,
+  signupConfirmationDialog,
 }: {
   sessionId: string;
   sport: string;
@@ -59,6 +60,7 @@ async function SessionSignupsContent({
   playerCap: number | null;
   viewData: StoredViewInstance[];
   isAdmin: boolean;
+  signupConfirmationDialog?: SignupConfirmationDialog;
 }) {
   const userId = user?.id ?? null;
   const canSignup = userRole >= signupRole;
@@ -77,6 +79,12 @@ async function SessionSignupsContent({
   const requestApproved = accessRequestStatus === "approved";
   const showTeamGate = needsTeamAccess && !requestApproved;
   const showSignupButton = canSignup || requestApproved;
+
+  // Only pass the dialog config if the user's role is at or below the configured maxRole
+  const activeDialog =
+    signupConfirmationDialog && !!user && userRole <= signupConfirmationDialog.maxRole
+      ? signupConfirmationDialog
+      : undefined;
 
   return (
     <div className="space-y-6">
@@ -98,11 +106,12 @@ async function SessionSignupsContent({
             userSignupStatus={userSignupStatus}
             isEligible
             showStatusText={false}
+            signupConfirmationDialog={activeDialog}
           />
         )}
       </div>
 
-      {(canSignup || requestApproved) && (
+      {user && (
         <div className="space-y-2">
           <AttendanceSection
             sport={sport}
@@ -313,6 +322,7 @@ export default async function SessionDetailPage({
           playerCap={session.player_cap}
           viewData={Array.isArray(session.alt_session_views) ? session.alt_session_views : []}
           isAdmin={isAdmin}
+          signupConfirmationDialog={tab.signupConfirmationDialog}
         />
       </Suspense>
     </div>

--- a/components/sports/session-signups-table.tsx
+++ b/components/sports/session-signups-table.tsx
@@ -63,8 +63,8 @@ export default function SessionSignupsTable({
         <Table>
           <TableHeader>
             <TableRow className="bg-muted/50">
-              <TableHead className="w-12">#</TableHead>
-              <TableHead className="w-8 px-1"></TableHead>
+              <TableHead className="w-8">#</TableHead>
+              <TableHead className="w-6 px-0"></TableHead>
               <TableHead>Name</TableHead>
               {showTimestamp && <TableHead>Signed up</TableHead>}
               <TableHead className={renderActions ? "" : "sticky right-0 bg-muted/50 border-l"}>
@@ -98,7 +98,7 @@ export default function SessionSignupsTable({
                       <TableCell className="font-mono text-xs">
                         {groupIndex}
                       </TableCell>
-                      <TableCell className="px-1 align-middle">
+                      <TableCell className="px-0 align-middle">
                         {teamMemberIds.has(signup.user_id) && <TeamMemberBadge />}
                       </TableCell>
                       <TableCell>

--- a/components/sports/session-views/custom-ordered-view.tsx
+++ b/components/sports/session-views/custom-ordered-view.tsx
@@ -77,8 +77,8 @@ export default function CustomOrderedView({
                 <Table>
                     <TableHeader>
                         <TableRow className="bg-muted/50">
-                            <TableHead className="w-12">#</TableHead>
-                            <TableHead className="w-8 px-1"></TableHead>
+                            <TableHead className="w-8">#</TableHead>
+                            <TableHead className="w-6 px-0"></TableHead>
                             <TableHead>Name</TableHead>
                         </TableRow>
                     </TableHeader>
@@ -93,7 +93,7 @@ export default function CustomOrderedView({
                                     <TableCell className="font-mono text-xs">
                                         {index + 1}
                                     </TableCell>
-                                    <TableCell className="px-1 align-middle">
+                                    <TableCell className="px-0 align-middle">
                                         {teamMemberIds.has(signup.user_id) && <TeamMemberBadge />}
                                     </TableCell>
                                     <TableCell>

--- a/components/sports/signup-button.tsx
+++ b/components/sports/signup-button.tsx
@@ -6,12 +6,23 @@ import { toast } from "sonner";
 import { Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import {
   signUpForSession,
   cancelSignup,
   declineSession,
   type SignupPlacement,
 } from "@/lib/actions/signups";
 import type { SignupStatus } from "@/lib/supabase/types";
+import type { SignupConfirmationDialog } from "@/config/config-resolver";
 import { feedback, toastClasses } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +34,8 @@ interface SignupButtonProps {
   userSignupStatus: SignupStatus | null;
   isEligible: boolean;
   showStatusText?: boolean;
+  /** When provided, shows a confirmation dialog before signup. */
+  signupConfirmationDialog?: SignupConfirmationDialog;
   className?: string;
   buttonClassName?: string;
 }
@@ -52,6 +65,7 @@ export default function SignupButton({
   userSignupStatus,
   isEligible,
   showStatusText = true,
+  signupConfirmationDialog,
   className,
   buttonClassName,
 }: SignupButtonProps) {
@@ -59,6 +73,8 @@ export default function SignupButton({
   const [pending, setPending] = useState(false);
   const [localStatus, setLocalStatus] = useState(userSignupStatus);
   const [error, setError] = useState<string | null>(null);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [showRejectedMessage, setShowRejectedMessage] = useState(false);
 
   const handleSignup = async () => {
     setPending(true);
@@ -76,15 +92,30 @@ export default function SignupButton({
     setPending(false);
   };
 
+  const initiateSignup = () => {
+    if (signupConfirmationDialog) {
+      setShowRejectedMessage(false);
+      setShowConfirmDialog(true);
+    } else {
+      handleSignup();
+    }
+  };
+
+  const handleConfirmYes = () => {
+    setShowConfirmDialog(false);
+    handleSignup();
+  };
+
   const handleCancel = async () => {
     setPending(true);
     setError(null);
+    const previousStatus = localStatus;
     const result = await cancelSignup(sessionId);
     if ("error" in result) {
       setError(result.error);
     } else {
       setLocalStatus("cancelled");
-      toast("Your sign-up has been cancelled.");
+      toast("Response removed.");
       router.refresh();
     }
     setPending(false);
@@ -103,6 +134,52 @@ export default function SignupButton({
     }
     setPending(false);
   };
+
+  const confirmationDialog = signupConfirmationDialog && (
+    <AlertDialog open={showConfirmDialog} onOpenChange={(open) => {
+      if (!open && !showRejectedMessage) setShowConfirmDialog(false);
+    }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Signup Confirmation</AlertDialogTitle>
+          <AlertDialogDescription>
+            {showRejectedMessage
+              ? signupConfirmationDialog.rejectedMessage
+              : signupConfirmationDialog.message}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-row justify-end">
+          {showRejectedMessage ? (
+            <AlertDialogCancel onClick={() => {
+              setShowConfirmDialog(false);
+            }}>
+              Dismiss
+            </AlertDialogCancel>
+          ) : (
+            <>
+              <AlertDialogAction onClick={(e) => {
+                e.preventDefault();
+                handleConfirmYes();
+              }}>
+                Yes
+              </AlertDialogAction>
+              <AlertDialogCancel onClick={(e) => {
+                e.preventDefault();
+                const hasRejectedMessage = !!signupConfirmationDialog.rejectedMessage;
+                if (hasRejectedMessage) {
+                  setShowRejectedMessage(true);
+                } else {
+                  setShowConfirmDialog(false);
+                }
+              }}>
+                No
+              </AlertDialogCancel>
+            </>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 
   if (localStatus === "confirmed" || localStatus === "waitlisted") {
     return (
@@ -123,7 +200,7 @@ export default function SignupButton({
             disabled={pending}
             className={cn("px-8", buttonClassName)}
           >
-            {pending ? "Cancelling..." : "Cancel Sign-up"}
+            {pending ? "Cancelling..." : "Remove Sign-up"}
           </Button>
         </div>
         {error && <p className={feedback.error}>{error}</p>}
@@ -141,17 +218,28 @@ export default function SignupButton({
               <span className="font-semibold">unable to join</span>.
             </span>
           )}
-          {isOpen && isEligible && (
+          <div className="flex flex-wrap gap-2">
+            {isOpen && isEligible && (
+              <Button
+                onClick={initiateSignup}
+                disabled={pending}
+                className={cn("px-8", buttonClassName)}
+              >
+                {pending ? "Signing up..." : "Sign up instead"}
+              </Button>
+            )}
             <Button
-              onClick={handleSignup}
+              variant="destructive"
+              onClick={handleCancel}
               disabled={pending}
               className={cn("px-8", buttonClassName)}
             >
-              {pending ? "Signing up..." : "Sign up instead"}
+              {pending ? "Cancelling..." : "Remove Attendance"}
             </Button>
-          )}
+          </div>
         </div>
         {error && <p className={feedback.error}>{error}</p>}
+        {confirmationDialog}
       </div>
     );
   }
@@ -161,7 +249,7 @@ export default function SignupButton({
       <Button
         disabled
         className={cn(
-          "w-full sm:w-auto px-8 has-[>svg]:px-8",
+          "px-8 has-[>svg]:px-8",
           buttonClassName,
         )}
       >
@@ -176,7 +264,7 @@ export default function SignupButton({
       <Button
         disabled
         className={cn(
-          "w-full sm:w-auto px-8 has-[>svg]:px-8",
+          "px-8 has-[>svg]:px-8",
           buttonClassName,
         )}
       >
@@ -189,10 +277,10 @@ export default function SignupButton({
     <div className={cn("space-y-2", className)}>
       <div className="flex flex-wrap gap-2">
         <Button
-          onClick={handleSignup}
+          onClick={initiateSignup}
           disabled={pending}
           className={cn(
-            "w-full sm:w-auto px-8 has-[>svg]:px-8",
+            "px-8 has-[>svg]:px-8",
             buttonClassName,
           )}
         >
@@ -203,7 +291,7 @@ export default function SignupButton({
           onClick={handleDecline}
           disabled={pending}
           className={cn(
-            "w-full sm:w-auto px-8",
+            "px-8",
             buttonClassName,
           )}
         >
@@ -211,6 +299,7 @@ export default function SignupButton({
         </Button>
       </div>
       {error && <p className={feedback.error}>{error}</p>}
+      {confirmationDialog}
     </div>
   );
 }

--- a/config/config-interfaces.ts
+++ b/config/config-interfaces.ts
@@ -30,6 +30,16 @@ export enum PillColor {
 /** Maps each access level to the minimum Role required. */
 export type TabPermissions = Record<AccessLevel, Role>;
 
+/** Confirmation dialog shown before signup for users at or below a given role. */
+export interface SignupConfirmationDialog {
+  /** Show the dialog for users whose role is at or below this level. */
+  maxRole: Role;
+  /** Prompt message asking the user to confirm eligibility. */
+  message: string;
+  /** Message shown when the user answers "No". */
+  rejectedMessage: string;
+}
+
 /** Default values applied to every tab during resolution. */
 export interface TabDefaults {
   permissions: TabPermissions;
@@ -61,6 +71,8 @@ export interface SessionTab {
   defaultTitlePrefix?: string;
   /** Color token used for session type pills. */
   sessionPillColor?: PillColor;
+  /** Optional confirmation dialog before signup for lower-role users. */
+  signupConfirmationDialog?: SignupConfirmationDialog;
 }
 
 export interface AdminTabMeta {

--- a/config/sports-config.ts
+++ b/config/sports-config.ts
@@ -126,7 +126,7 @@ export const sportsConfig: Record<string, SportConfig> = {
     ],
     emoji: "🥎",
     name: "Softball",
-    type: "Drop-in Practice & Scheduled CCSA Games",
+    type: "Drop-in Practices & Scheduled CCSA Games",
     location: {
       name: "Various locations",
       address: "See individual sessions",
@@ -135,7 +135,7 @@ export const sportsConfig: Record<string, SportConfig> = {
     organizers: "Brandon Cho, Joshua Wong, Isaac Ng",
     notes: [
       "Our team plays in the CCSA (Christian Community Softball Association), a Toronto-area church softball league that runs during the summer with Senior and Junior divisions.",
-      "Team registration for the 2026 season is now closed, but you're welcome to join our drop-in practice sessions! It's a great time for us to connect not only through the game but also with each other and the message of the gospel. Everyone, regardless of your faith background, is welcome.",
+      "Team registration for the 2026 season is now closed, but if you're an NTCBC Member, you're welcome to join our drop-in practice sessions! It's a great time for us to connect not only through the game but also with each other and the message of the gospel. Everyone, regardless of your faith background, is welcome.",
       "Softball has two session types: Drop-in Practice (open to all) & Scheduled Games (team members only).",
       "Sign in with Google to sign up for sessions. If you can no longer attend, please cancel your signup.",
       "Please contact the leaders if you have any questions.",
@@ -148,7 +148,12 @@ export const sportsConfig: Record<string, SportConfig> = {
         label: "Drop-in Practice",
         defaultTitlePrefix: "Practice",
         sessionPillColor: PillColor.emerald,
-        permissions: { [AccessLevel.view]: Role.user },
+        permissions: { [AccessLevel.view]: Role.user, [AccessLevel.signup]: Role.user },
+        signupConfirmationDialog: {
+          maxRole: Role.user,
+          message: "Do you go to NTCBC? (Only) If not, have you been approved by a leader to participate?",
+          rejectedMessage: "This session is for team members, NTCBC goers and approved participants. Please contact the leaders if you'd like to join.",
+        },
       },
       {
         value: "scheduled_game",

--- a/lib/actions/signups.ts
+++ b/lib/actions/signups.ts
@@ -164,7 +164,7 @@ export async function cancelSignup(
     .maybeSingle();
 
   if (fetchError) return { error: fetchError.message };
-  if (!row || row.status === "cancelled" || row.status === "declined") {
+  if (!row || row.status === "cancelled") {
     revalidatePath(`/${sport}/session/${sessionId}`);
     revalidatePath(`/${sport}`);
     return { success: true };

--- a/supabase/migrations/20260523000000_allow_authenticated_read_sport_roles.sql
+++ b/supabase/migrations/20260523000000_allow_authenticated_read_sport_roles.sql
@@ -1,0 +1,10 @@
+-- Allow any authenticated user to read sport_roles.
+-- This enables non-team-members to see team member badges in attendance lists.
+-- The previous policy restricted reads to own row / admin / team member only,
+-- which caused getTeamMembers() to return empty for regular users.
+
+drop policy if exists "sport_roles_read" on public.sport_roles;
+
+create policy "sport_roles_read"
+  on public.sport_roles for select
+  using (auth.uid() is not null);


### PR DESCRIPTION
## Summary

Adds a declarative `signupConfirmationDialog` config per tab that prompts non-team-member users before signing up.

## Changes

- **Config**: New `SignupConfirmationDialog` interface (`maxRole`, `message`, `rejectedMessage`) on `SessionTab`
- **Softball**: Configured on `drop_in_practice` — asks users at/below `Role.user` to confirm NTCBC membership
- **SignupButton**: Shows Yes/No dialog before signup; "No" keeps dialog open with rejected message + Dismiss
- **Backend**: `cancelSignup` now allows transition from `declined` → `cancelled` (undo "unable to join")
- **RLS**: Relaxed `sport_roles` SELECT to all authenticated users so team member badges are visible to everyone
- **UI**: Tightened `#` and badge column spacing in signup tables