### PR TITLE
Allow admins to promote/demote signups in Attendance view

### DIFF
--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -20,7 +20,7 @@ import SessionDialog from "@/components/sports/session-dialog";
 import StatusBanner from "@/components/sports/status-banner";
 import AdminButton from "@/components/sports/admin-button";
 import { isSignupOpen } from "@/lib/signup-capacity";
-import AttendanceSection from "@/components/sports/attendance-section";
+import SessionViewSection from "@/components/sports/session-view-section";
 import CountdownTimer from "@/components/sports/countdown-timer";
 import LocalTimestamp from "@/components/sports/local-timestamp";
 
@@ -113,7 +113,7 @@ async function SessionSignupsContent({
 
       {user && (
         <div className="space-y-2">
-          <AttendanceSection
+          <SessionViewSection
             sport={sport}
             sessionId={sessionId}
             signups={rawSignups}

--- a/components/sports/session-signups-table.tsx
+++ b/components/sports/session-signups-table.tsx
@@ -60,6 +60,7 @@ export default function SessionSignupsTable({
           No sign-ups yet.
         </div>
       ) : (
+        <div className="overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow className="bg-muted/50">
@@ -67,19 +68,17 @@ export default function SessionSignupsTable({
               <TableHead className="w-6 px-0"></TableHead>
               <TableHead>Name</TableHead>
               {showTimestamp && <TableHead>Signed up</TableHead>}
-              <TableHead className={renderActions ? "" : "sticky right-0 bg-muted/50 border-l"}>
-                Status
+              <TableHead className="sticky right-0 bg-card border-l z-10">
+                <div className="absolute inset-0 bg-muted/50" />
+                <span className="relative">Status</span>
               </TableHead>
-              {renderActions && (
-                <TableHead className="text-right">Actions</TableHead>
-              )}
             </TableRow>
           </TableHeader>
           <TableBody>
             {(() => {
               let activeIndex = 0;
               let declinedIndex = 0;
-              const colCount = 3 + (showTimestamp ? 1 : 0) + 1 + (renderActions ? 1 : 0);
+              const colCount = 3 + (showTimestamp ? 1 : 0) + 1;
               return sortedSignups.map((signup) => {
                 const isCurrentUser = currentUserId === signup.user_id;
                 const isDeclined = signup.status === "declined";
@@ -109,14 +108,12 @@ export default function SessionSignupsTable({
                           <LocalTimestamp date={signup.created_at} />
                         </TableCell>
                       )}
-                      <TableCell className={renderActions ? "" : `sticky right-0 border-l group-hover:bg-muted/50 ${isCurrentUser ? "bg-status-info" : "bg-card"}`}>
-                        <StatusBadge status={signup.status as "confirmed" | "waitlisted" | "declined"} />
+                      <TableCell className={`sticky right-0 border-l group-hover:bg-muted/50 ${isCurrentUser ? "bg-status-info" : "bg-card"}`}>
+                        <div className="flex items-center justify-between gap-1">
+                          <StatusBadge status={signup.status as "confirmed" | "waitlisted" | "declined"} />
+                          {renderActions && renderActions(signup)}
+                        </div>
                       </TableCell>
-                      {renderActions && (
-                        <TableCell className="text-right">
-                          {renderActions(signup)}
-                        </TableCell>
-                      )}
                     </TableRow>
                   </Fragment>
                 );
@@ -124,6 +121,7 @@ export default function SessionSignupsTable({
             })()}
           </TableBody>
         </Table>
+        </div>
       )}
     </div>
   );

--- a/components/sports/session-signups-table.tsx
+++ b/components/sports/session-signups-table.tsx
@@ -43,9 +43,8 @@ export default function SessionSignupsTable({
   const allSignups = signups.filter((s) => s.status !== "cancelled");
   const confirmed = allSignups.filter((s) => s.status === "confirmed");
   const waitlisted = allSignups.filter((s) => s.status === "waitlisted");
-  const activeSignups = allSignups.filter((s) => s.status !== "declined");
   const declinedSignups = allSignups.filter((s) => s.status === "declined");
-  const sortedSignups = [...activeSignups, ...declinedSignups];
+  const sortedSignups = [...confirmed, ...waitlisted, ...declinedSignups];
 
   return (
     <div className="overflow-hidden rounded-lg border bg-card">
@@ -76,17 +75,30 @@ export default function SessionSignupsTable({
           </TableHeader>
           <TableBody>
             {(() => {
-              let activeIndex = 0;
+              let confirmedIndex = 0;
+              let waitlistedIndex = 0;
               let declinedIndex = 0;
               const colCount = 3 + (showTimestamp ? 1 : 0) + 1;
               return sortedSignups.map((signup) => {
                 const isCurrentUser = currentUserId === signup.user_id;
+                const isWaitlisted = signup.status === "waitlisted";
                 const isDeclined = signup.status === "declined";
-                const groupIndex = isDeclined ? ++declinedIndex : ++activeIndex;
-                const showDivider = isDeclined && declinedIndex === 1;
+                let groupIndex: number;
+                if (isDeclined) groupIndex = ++declinedIndex;
+                else if (isWaitlisted) groupIndex = ++waitlistedIndex;
+                else groupIndex = ++confirmedIndex;
+                const showWaitlistDivider = isWaitlisted && waitlistedIndex === 1;
+                const showDeclinedDivider = isDeclined && declinedIndex === 1;
                 return (
                   <Fragment key={signup.id}>
-                    {showDivider && (
+                    {showWaitlistDivider && (
+                      <TableRow className="pointer-events-none">
+                        <TableCell colSpan={colCount} className="py-1 px-4">
+                          <div className="border-t border-dashed border-border" />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {showDeclinedDivider && (
                       <TableRow className="pointer-events-none">
                         <TableCell colSpan={colCount} className="py-1 px-4">
                           <div className="border-t border-dashed border-border" />
@@ -108,7 +120,7 @@ export default function SessionSignupsTable({
                           <LocalTimestamp date={signup.created_at} />
                         </TableCell>
                       )}
-                      <TableCell className={`sticky right-0 border-l group-hover:bg-muted/50 ${isCurrentUser ? "bg-status-info" : "bg-card"}`}>
+                      <TableCell className={`sticky right-0 border-l group-hover:bg-muted ${isCurrentUser ? "bg-status-info" : "bg-card"}`}>
                         <div className="flex items-center justify-between gap-1">
                           <StatusBadge status={signup.status as "confirmed" | "waitlisted" | "declined"} />
                           {renderActions && renderActions(signup)}

--- a/components/sports/session-view-section.tsx
+++ b/components/sports/session-view-section.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
-import SessionSignupsTable from "@/components/sports/session-signups-table";
+import AttendanceView from "@/components/sports/session-views/attendance-view";
 import ViewToggle from "@/components/sports/view-toggle";
 import EditViewsDialog from "@/components/sports/edit-views-dialog";
 import { getSessionView, DEFAULT_VIEW_TYPE } from "@/components/sports/session-views/registry";
@@ -10,7 +10,7 @@ import { displayName } from "@/lib/format";
 import type { SignupRow } from "@/components/sports/session-signups-table";
 import type { StoredViewInstance } from "@/lib/supabase/types";
 
-interface AttendanceSectionProps {
+interface SessionViewSectionProps {
     sport: string;
     sessionId: string;
     signups: SignupRow[];
@@ -29,7 +29,7 @@ interface AttendanceSectionProps {
  * - Non-empty, all disabled: shows collapsed hint (count + user's row).
  * - Non-empty, has enabled: shows view toggle + active view component.
  */
-export default function AttendanceSection({
+export default function SessionViewSection({
     sport,
     sessionId,
     signups,
@@ -38,7 +38,7 @@ export default function AttendanceSection({
     currentUserId,
     viewData,
     isAdmin,
-}: AttendanceSectionProps) {
+}: SessionViewSectionProps) {
     const searchParams = useSearchParams();
     const [activeView, setActiveView] = useState<string | null>(
         searchParams.get("view"),
@@ -56,7 +56,7 @@ export default function AttendanceSection({
         window.history.replaceState(null, "", newUrl);
     };
 
-    // Empty viewData = no views configured yet → show attendance table directly
+    // Empty viewData = no views configured yet → fall back to attendance view
     if (viewData.length === 0) {
         return (
             <div className="space-y-2">
@@ -72,12 +72,15 @@ export default function AttendanceSection({
                         />
                     )}
                 </div>
-                <SessionSignupsTable
+                <AttendanceView
                     signups={signups}
                     teamMemberIds={teamMemberIds}
                     playerCap={playerCap}
                     currentUserId={currentUserId}
-                    showTimestamp
+                    viewData={null}
+                    isAdmin={isAdmin}
+                    sport={sport}
+                    sessionId={sessionId}
                 />
             </div>
         );
@@ -129,6 +132,9 @@ export default function AttendanceSection({
                     playerCap={playerCap}
                     currentUserId={currentUserId}
                     viewData={activeInstance!.data}
+                    isAdmin={isAdmin}
+                    sport={sport}
+                    sessionId={sessionId}
                 />
             ) : configuredViews.length === 0 ? (
                 <CollapsedAttendanceHint

--- a/components/sports/session-view-section.tsx
+++ b/components/sports/session-view-section.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import AttendanceView from "@/components/sports/session-views/attendance-view";
 import ViewToggle from "@/components/sports/view-toggle";
 import EditViewsDialog from "@/components/sports/edit-views-dialog";
-import { getSessionView, DEFAULT_VIEW_TYPE } from "@/components/sports/session-views/registry";
+import { getSessionView } from "@/components/sports/session-views/registry";
 import { displayName } from "@/lib/format";
 import type { SignupRow } from "@/components/sports/session-signups-table";
 import type { StoredViewInstance } from "@/lib/supabase/types";

--- a/components/sports/session-views/attendance-view.tsx
+++ b/components/sports/session-views/attendance-view.tsx
@@ -3,8 +3,11 @@
 import { useImperativeHandle, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowDown, ArrowUp } from "lucide-react";
+import { toast } from "sonner";
 import SessionSignupsTable from "@/components/sports/session-signups-table";
 import { adminUpdateSignupStatus } from "@/lib/actions/signups";
+import { toastClasses } from "@/lib/styles";
+import { displayName } from "@/lib/format";
 import type { SignupRow } from "@/components/sports/session-signups-table";
 import type { SessionViewProps, SessionViewEditorProps } from "./interfaces";
 
@@ -24,11 +27,22 @@ export default function AttendanceView({
 }: SessionViewProps) {
     const [pending, setPending] = useState<string | null>(null);
 
-    const handleStatusChange = async (signupId: string, status: "confirmed" | "waitlisted") => {
+    const handleStatusChange = async (signup: SignupRow, status: "confirmed" | "waitlisted") => {
         if (!sport || !sessionId) return;
-        setPending(signupId);
-        await adminUpdateSignupStatus(sport, signupId, status, sessionId);
+        setPending(signup.id);
+        const result = await adminUpdateSignupStatus(sport, signup.id, status, sessionId);
         setPending(null);
+        if ("error" in result) {
+            toast(result.error, { className: toastClasses.red });
+        } else {
+            const name = displayName(signup.profiles);
+            const message = status === "confirmed"
+                ? `${name} promoted to confirmed`
+                : `${name} moved to waitlist`;
+            toast(message, {
+                className: status === "confirmed" ? toastClasses.green : toastClasses.amber,
+            });
+        }
     };
 
     const renderActions = isAdmin && sport && sessionId
@@ -39,7 +53,7 @@ export default function AttendanceView({
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
-                        onClick={() => handleStatusChange(signup.id, "waitlisted")}
+                        onClick={() => handleStatusChange(signup, "waitlisted")}
                         disabled={pending === signup.id}
                         title="Move to waitlist"
                     >
@@ -51,7 +65,7 @@ export default function AttendanceView({
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
-                        onClick={() => handleStatusChange(signup.id, "confirmed")}
+                        onClick={() => handleStatusChange(signup, "confirmed")}
                         disabled={pending === signup.id}
                         title="Promote to confirmed"
                     >

--- a/components/sports/session-views/attendance-view.tsx
+++ b/components/sports/session-views/attendance-view.tsx
@@ -1,19 +1,67 @@
 "use client";
 
-import { useImperativeHandle } from "react";
+import { useImperativeHandle, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ArrowDown, ArrowUp } from "lucide-react";
 import SessionSignupsTable from "@/components/sports/session-signups-table";
+import { adminUpdateSignupStatus } from "@/lib/actions/signups";
+import type { SignupRow } from "@/components/sports/session-signups-table";
 import type { SessionViewProps, SessionViewEditorProps } from "./interfaces";
 
 /**
  * The default attendance view — wraps SessionSignupsTable.
  * No stored data; simply shows signups with timestamps.
+ * When admin context is provided, renders promote/demote action buttons.
  */
 export default function AttendanceView({
     signups,
     teamMemberIds,
     playerCap,
     currentUserId,
+    isAdmin,
+    sport,
+    sessionId,
 }: SessionViewProps) {
+    const [pending, setPending] = useState<string | null>(null);
+
+    const handleStatusChange = async (signupId: string, status: "confirmed" | "waitlisted") => {
+        if (!sport || !sessionId) return;
+        setPending(signupId);
+        await adminUpdateSignupStatus(sport, signupId, status, sessionId);
+        setPending(null);
+    };
+
+    const renderActions = isAdmin && sport && sessionId
+        ? (signup: SignupRow) => (
+            <>
+                {signup.status === "confirmed" && (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => handleStatusChange(signup.id, "waitlisted")}
+                        disabled={pending === signup.id}
+                        title="Move to waitlist"
+                    >
+                        <ArrowDown className="h-4 w-4" />
+                    </Button>
+                )}
+                {signup.status === "waitlisted" && (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => handleStatusChange(signup.id, "confirmed")}
+                        disabled={pending === signup.id}
+                        title="Promote to confirmed"
+                    >
+                        <ArrowUp className="h-4 w-4" />
+                    </Button>
+                )}
+            </>
+        )
+        : undefined;
+
     return (
         <SessionSignupsTable
             signups={signups}
@@ -21,6 +69,7 @@ export default function AttendanceView({
             playerCap={playerCap}
             currentUserId={currentUserId}
             showTimestamp
+            renderActions={renderActions}
         />
     );
 }

--- a/components/sports/session-views/interfaces.ts
+++ b/components/sports/session-views/interfaces.ts
@@ -9,6 +9,10 @@ export interface SessionViewProps {
     currentUserId?: string | null;
     /** The stored data for this view. */
     viewData: unknown;
+    /** Optional admin context — when present, views may render admin actions. */
+    isAdmin?: boolean;
+    sport?: string;
+    sessionId?: string;
 }
 
 /**


### PR DESCRIPTION
Adds admin actions to the Attendance session view for managing signup status:

- **Promote** waitlisted → confirmed (↑ arrow)
- **Demote** confirmed → waitlisted (↓ arrow)
- Toast feedback on success/error (green/amber/red)

Also includes:
- Waitlist section separated by dashed divider (confirmed → waitlisted → declined)
- Status + actions in sticky-right cell (visible on horizontal scroll)
- Rename `AttendanceSection` → `SessionViewSection`
- Fallback (no views configured) now renders `AttendanceView` directly