### PR TITLE
chore: improve admin mobile UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
+  workflow_dispatch:
   merge_group:
     types: [checks_requested]
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
 

--- a/components/sports/admin/admin-access-requests.tsx
+++ b/components/sports/admin/admin-access-requests.tsx
@@ -45,58 +45,105 @@ export default function AdminAccessRequests({ sport, requests }: AdminAccessRequ
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border bg-card">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-muted/50">
-            <TableHead>Name</TableHead>
-            <TableHead>Email</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Requested</TableHead>
-            <TableHead className="text-center">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {requests.map((request) => (
-            <TableRow key={request.id}>
-              <TableCell>{displayName(request.profiles)}</TableCell>
-              <TableCell className="text-sm text-muted-foreground">
-                {request.profiles?.email ?? "—"}
-              </TableCell>
-              <TableCell>
-                <StatusBadge status={request.status} />
-              </TableCell>
-              <TableCell className="text-xs text-muted-foreground">
+    <>
+      {/* Mobile card layout */}
+      <div className="md:hidden space-y-3">
+        {requests.map((request) => (
+          <div key={request.id} className="rounded-lg border bg-card p-4 space-y-3">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-sm truncate">{displayName(request.profiles)}</p>
+                <p className="text-xs text-muted-foreground truncate mt-0.5">
+                  {request.profiles?.email ?? "—"}
+                </p>
+              </div>
+              <StatusBadge status={request.status} />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">
                 {formatDate(request.created_at.split("T")[0]!)}
-              </TableCell>
-              <TableCell>
-                <div className="flex justify-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleReview(request.id, "approved")}
-                    disabled={pending === request.id || request.status === "approved"}
-                    className={`${colors.successHover} disabled:opacity-20`}
-                    title="Approve"
-                  >
-                    <Check className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleReview(request.id, "rejected")}
-                    disabled={pending === request.id || request.status === "rejected"}
-                    className={`${colors.destructiveHover} disabled:opacity-20`}
-                    title="Reject"
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
-              </TableCell>
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleReview(request.id, "approved")}
+                  disabled={pending === request.id || request.status === "approved"}
+                  className={`${colors.successHover} disabled:opacity-20 h-9 px-3`}
+                >
+                  <Check className="h-4 w-4 mr-1.5" />
+                  Approve
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleReview(request.id, "rejected")}
+                  disabled={pending === request.id || request.status === "rejected"}
+                  className={`${colors.destructiveHover} disabled:opacity-20 h-9 px-3`}
+                >
+                  <X className="h-4 w-4 mr-1.5" />
+                  Reject
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop table layout */}
+      <div className="hidden md:block overflow-hidden rounded-lg border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/50">
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Requested</TableHead>
+              <TableHead className="text-center">Actions</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {requests.map((request) => (
+              <TableRow key={request.id}>
+                <TableCell>{displayName(request.profiles)}</TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {request.profiles?.email ?? "—"}
+                </TableCell>
+                <TableCell>
+                  <StatusBadge status={request.status} />
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {formatDate(request.created_at.split("T")[0]!)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex justify-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleReview(request.id, "approved")}
+                      disabled={pending === request.id || request.status === "approved"}
+                      className={`${colors.successHover} disabled:opacity-20 h-8 px-2.5`}
+                    >
+                      <Check className="h-4 w-4 mr-1" />
+                      Approve
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleReview(request.id, "rejected")}
+                      disabled={pending === request.id || request.status === "rejected"}
+                      className={`${colors.destructiveHover} disabled:opacity-20 h-8 px-2.5`}
+                    >
+                      <X className="h-4 w-4 mr-1" />
+                      Reject
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/components/sports/admin/admin-session-accordion.tsx
+++ b/components/sports/admin/admin-session-accordion.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Badge } from "@/components/ui/badge";
 import {
   Accordion,
@@ -6,7 +8,13 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import { CalendarDays, MapPin, Pencil } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CalendarDays, MapPin, MoreVertical, Pencil } from "lucide-react";
 import { getResolvedTab, type ResolvedSportConfig } from "@/config/config-resolver";
 import AdminSessionSignups from "@/components/sports/admin/admin-session-signups";
 import DeleteSessionButton from "@/components/sports/session/delete-session-button";
@@ -121,14 +129,16 @@ export default function SessionAccordion({
                     {formatTime(session.time_start)} – {formatTime(session.time_end)} ·{" "}
                     {session.location_address}
                   </div>
-                  <div className="flex shrink-0 items-center gap-1 -mt-1">
+
+                  {/* Desktop: inline action buttons */}
+                  <div className="hidden md:flex shrink-0 items-center gap-1.5 -mt-1">
                     <SessionDialog
                       sport={sport}
                       sessionTabs={sessionTabs}
                       defaultTab={config.defaultTab}
                       session={session}
                       trigger={
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <Button variant="ghost" size="icon" className="h-9 w-9">
                           <Pencil className="h-4 w-4" />
                           <span className="sr-only">Edit {session.title || "session"}</span>
                         </Button>
@@ -141,6 +151,39 @@ export default function SessionAccordion({
                       <CancelSessionButton sport={sport} sessionId={session.id} />
                     )}
                     <DeleteSessionButton sport={sport} sessionId={session.id} />
+                  </div>
+
+                  {/* Mobile: overflow dropdown menu */}
+                  <div className="md:hidden shrink-0 -mt-1">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon" className="h-10 w-10">
+                          <MoreVertical className="h-5 w-5" />
+                          <span className="sr-only">Session actions</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <SessionDialog
+                          sport={sport}
+                          sessionTabs={sessionTabs}
+                          defaultTab={config.defaultTab}
+                          session={session}
+                          trigger={
+                            <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                              <Pencil className="h-4 w-4 mr-2" />
+                              Edit
+                            </DropdownMenuItem>
+                          }
+                        />
+                        {session.status === SESSION_STATUS.cancelled && (
+                          <RestoreSessionButton sport={sport} sessionId={session.id} asMenuItem />
+                        )}
+                        {session.status !== SESSION_STATUS.cancelled && (
+                          <CancelSessionButton sport={sport} sessionId={session.id} asMenuItem />
+                        )}
+                        <DeleteSessionButton sport={sport} sessionId={session.id} asMenuItem />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 </div>
                 <AdminSessionSignups

--- a/components/sports/admin/admin-session-signups.tsx
+++ b/components/sports/admin/admin-session-signups.tsx
@@ -44,7 +44,7 @@ export default function AdminSessionSignups({
       teamMemberIds={teamMemberIds ?? new Set()}
       playerCap={playerCap}
       renderActions={(signup) => (
-        <div className="flex justify-end gap-1">
+        <div className="flex justify-end gap-1.5">
           {signup.status === "waitlisted" && (
             <Button
               variant="ghost"
@@ -52,6 +52,7 @@ export default function AdminSessionSignups({
               onClick={() => handlePromote(signup.id)}
               disabled={pending === signup.id}
               title="Promote to confirmed"
+              className="h-9 w-9"
             >
               <ArrowUp className="h-4 w-4" />
             </Button>
@@ -62,7 +63,7 @@ export default function AdminSessionSignups({
             onClick={() => handleCancel(signup.id)}
             disabled={pending === signup.id}
             title="Remove signup"
-            className={colors.destructiveHover}
+            className={`${colors.destructiveHover} h-9 w-9`}
           >
             <X className="h-4 w-4" />
           </Button>

--- a/components/sports/admin/admin-sidebar.tsx
+++ b/components/sports/admin/admin-sidebar.tsx
@@ -98,32 +98,36 @@ export default function AdminLayout({
         ))}
       </nav>
 
-      {/* Mobile horizontal tabs */}
-      <nav className="md:hidden flex gap-1 overflow-x-auto pb-2 -mx-1 px-1">
-        {allTabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => navigate(tab.id)}
-            className={cn(
-              "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors",
-              activeTab === tab.id
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground bg-muted hover:bg-accent",
-            )}
-          >
-            <tab.icon className="h-3.5 w-3.5 shrink-0" />
-            {tab.label}
-            {tab.id === "requests" && pendingRequestCount > 0 && (
-              <Badge
-                variant={activeTab === tab.id ? "secondary" : "destructive"}
-                className="h-4 min-w-4 flex items-center justify-center px-1 text-[10px]"
-              >
-                {pendingRequestCount}
-              </Badge>
-            )}
-          </button>
-        ))}
-      </nav>
+      {/* Mobile horizontal tabs with scroll fade */}
+      <div className="md:hidden relative">
+        <nav className="flex gap-1.5 overflow-x-auto pb-2 -mx-1 px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {allTabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => navigate(tab.id)}
+              className={cn(
+                "flex items-center gap-1.5 px-3 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors min-h-[40px]",
+                activeTab === tab.id
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground bg-muted hover:bg-accent",
+              )}
+            >
+              <tab.icon className="h-4 w-4 shrink-0" />
+              {tab.label}
+              {tab.id === "requests" && pendingRequestCount > 0 && (
+                <Badge
+                  variant={activeTab === tab.id ? "secondary" : "destructive"}
+                  className="h-5 min-w-5 flex items-center justify-center px-1.5 text-xs"
+                >
+                  {pendingRequestCount}
+                </Badge>
+              )}
+            </button>
+          ))}
+        </nav>
+        {/* Scroll fade hint */}
+        <div className="pointer-events-none absolute right-0 top-0 bottom-2 w-8 bg-gradient-to-l from-background to-transparent" />
+      </div>
 
       {/* Content area — show loading instantly on tab switch */}
       <div className="flex-1 min-w-0">

--- a/components/sports/admin/admin-tabs/create.tsx
+++ b/components/sports/admin/admin-tabs/create.tsx
@@ -12,7 +12,7 @@ export default async function AdminTabCreate({ sport }: { sport: string }) {
   return (
     <section className="space-y-3">
       <h2 className="text-lg font-semibold text-foreground">Create Session</h2>
-      <div className="rounded-lg border bg-card p-6">
+      <div className="rounded-lg border bg-card p-4 sm:p-6">
         <SessionForm sport={sport} sessionTabs={sessionTabs} defaultTab={config.defaultTab} />
       </div>
     </section>

--- a/components/sports/admin/admin-tabs/settings/dialogs.tsx
+++ b/components/sports/admin/admin-tabs/settings/dialogs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { Dispatch, SetStateAction } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/components/sports/admin/admin-tabs/settings/form-sections.tsx
+++ b/components/sports/admin/admin-tabs/settings/form-sections.tsx
@@ -56,7 +56,7 @@ export function GeneralSettingsSection({ state, setState }: GeneralSettingsSecti
         <Label htmlFor="auth-enabled">Enable Google Login</Label>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 pt-4">
+      <div className="grid gap-4 sm:grid-cols-2 pt-4 min-w-0">
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>
           <Input

--- a/components/sports/admin/admin-tabs/settings/form-sections.tsx
+++ b/components/sports/admin/admin-tabs/settings/form-sections.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import { useState, type Dispatch, type SetStateAction } from "react";
 import { CalendarDays, Pencil, Plus, Shield, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { DraggableList } from "@/components/ui/draggable-list";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,12 +44,7 @@ export function GeneralSettingsSection({ state, setState }: GeneralSettingsSecti
   const [showPreview, setShowPreview] = useState(false);
 
   return (
-    <div className="rounded-lg border bg-card p-6 space-y-4">
-      <div className="space-y-1">
-        <h3 className="text-base font-semibold text-foreground">General</h3>
-        <p className="text-sm text-muted-foreground">Basic info and logistics for this sport.</p>
-      </div>
-
+    <CollapsibleSection title="General" description="Basic info and logistics for this sport.">
       <div className="flex items-center gap-2 pt-4">
         <input
           id="auth-enabled"
@@ -58,7 +56,7 @@ export function GeneralSettingsSection({ state, setState }: GeneralSettingsSecti
         <Label htmlFor="auth-enabled">Enable Google Login</Label>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 pt-4 min-w-0 [&>*]:min-w-0">
+      <div className="grid gap-4 sm:grid-cols-2 pt-4">
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>
           <Input
@@ -177,7 +175,7 @@ export function GeneralSettingsSection({ state, setState }: GeneralSettingsSecti
           </div>
         </div>
       </div>
-    </div>
+    </CollapsibleSection>
   );
 }
 
@@ -205,14 +203,10 @@ export function SessionTabsSection({
   const [showPreview, setShowPreview] = useState(false);
 
   return (
-    <div className="rounded-lg border bg-card p-6 space-y-4">
-      <div className="space-y-1">
-        <h3 className="text-base font-semibold text-foreground">Sports Page</h3>
-        <p className="text-sm text-muted-foreground">
-          Configure the public-facing page content and session tabs.
-        </p>
-      </div>
-
+    <CollapsibleSection
+      title="Sports Page"
+      description="Configure the public-facing page content and session tabs."
+    >
       <div className="space-y-2 pt-4">
         <Label htmlFor="notes">Notes (one per line)</Label>
         <Textarea
@@ -402,7 +396,7 @@ export function SessionTabsSection({
           </div>
         </div>
       </div>
-    </div>
+    </CollapsibleSection>
   );
 }
 
@@ -428,14 +422,10 @@ export function AdminTabsSection({
   const SettingsTabIcon = getAdminTabIcon(SETTINGS_TAB_ICON_NAME);
 
   return (
-    <div className="rounded-lg border bg-card p-6 space-y-4">
-      <div className="space-y-1">
-        <h3 className="text-base font-semibold text-foreground">Admin Page</h3>
-        <p className="text-sm text-muted-foreground">
-          Choose which admin pages appear in the sidebar, then drag to reorder them.
-        </p>
-      </div>
-
+    <CollapsibleSection
+      title="Admin Page"
+      description="Choose which admin pages appear in the sidebar, then drag to reorder them."
+    >
       <div className="space-y-2 pt-4">
         <Label htmlFor="default-admin-tab">Default admin tab</Label>
         <Select
@@ -536,7 +526,7 @@ export function AdminTabsSection({
         <Plus className="h-3.5 w-3.5 mr-1" />
         Add Admin Tab
       </Button>
-    </div>
+    </CollapsibleSection>
   );
 }
 
@@ -549,16 +539,30 @@ interface FormActionsRowProps {
 
 export function FormActionsRow({ isDirty, isPending, onReset, onSave }: FormActionsRowProps) {
   return (
-    <div className="flex items-center gap-2">
-      <Button type="button" variant="outline" disabled={!isDirty} onClick={onReset}>
-        Reset
-      </Button>
-      <Button type="button" disabled={!isDirty || isPending} onClick={onSave}>
-        {isPending ? "Saving..." : "Save"}
-      </Button>
-      <span className="text-xs text-muted-foreground">
-        {isDirty ? "Unsaved local changes" : "No local changes"}
-      </span>
-    </div>
+    <>
+      {/* Spacer to prevent content from being hidden behind sticky bar */}
+      {isDirty && <div className="h-16" />}
+
+      {/* Sticky bottom bar when dirty */}
+      <div
+        className={cn(
+          isDirty
+            ? "fixed bottom-0 left-0 right-0 z-50 border-t bg-background/95 backdrop-blur-sm p-3 shadow-lg"
+            : "",
+        )}
+      >
+        <div className={cn("flex items-center gap-2", isDirty && "max-w-6xl mx-auto")}>
+          <Button type="button" variant="outline" disabled={!isDirty} onClick={onReset}>
+            Reset
+          </Button>
+          <Button type="button" disabled={!isDirty || isPending} onClick={onSave}>
+            {isPending ? "Saving..." : "Save"}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {isDirty ? "Unsaved local changes" : "No local changes"}
+          </span>
+        </div>
+      </div>
+    </>
   );
 }

--- a/components/sports/admin/admin-tabs/settings/index.tsx
+++ b/components/sports/admin/admin-tabs/settings/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/config/admin-tab-metadata";
 import { SESSION_TAB_RULES } from "@/config/session-tab-rules";
 import { updateSportConfig, type UpdateSportConfigInput } from "@/lib/actions/sport-config";
-import { toastClasses } from "@/lib/styles";
+import { statusColors, toastClasses } from "@/lib/styles";
 import { AUTO_DEFAULT_ADMIN_TAB_VALUE, AUTO_DEFAULT_TAB_VALUE } from "./constants";
 import { ADMIN_TAB_DEFINITIONS, ADMIN_TAB_ICON_OPTIONS } from "./admin-tab-ui-metadata";
 import { AdminTabDialog, DeleteTargetDialog, PermissionsDialog, SessionTabDialog } from "./dialogs";
@@ -713,6 +713,16 @@ export default function SportConfigForm({ sport, initialConfig }: SportConfigFor
 
   return (
     <section className="space-y-4">
+      {isDirty && (
+        <div className="sticky top-0 z-40 -mx-1 px-1">
+          <div
+            className={`rounded-lg border px-3 py-2 text-xs font-medium ${statusColors.amber.border} ${statusColors.amber.bg} ${statusColors.amber.text}`}
+          >
+            You have unsaved changes
+          </div>
+        </div>
+      )}
+
       <GeneralSettingsSection state={state} setState={setState} />
 
       <SessionTabsSection

--- a/components/sports/session/cancel-session-button.tsx
+++ b/components/sports/session/cancel-session-button.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { XCircle } from "lucide-react";
 import { cancelSession } from "@/lib/actions/sessions";
@@ -24,12 +25,15 @@ interface CancelSessionButtonProps {
   sessionId: string;
   /** Render a full-width button instead of an icon-only button. */
   variant?: "icon" | "full";
+  /** Render as a dropdown menu item instead of a button. */
+  asMenuItem?: boolean;
 }
 
 export default function CancelSessionButton({
   sport,
   sessionId,
   variant = "icon",
+  asMenuItem,
 }: CancelSessionButtonProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -55,7 +59,12 @@ export default function CancelSessionButton({
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        {variant === "icon" ? (
+        {asMenuItem ? (
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+            <XCircle className="h-4 w-4 mr-2" />
+            Cancel Session
+          </DropdownMenuItem>
+        ) : variant === "icon" ? (
           <Button variant="ghost" size="sm" className={colors.warningHover} title="Cancel session">
             <XCircle className="h-4 w-4" />
           </Button>

--- a/components/sports/session/delete-session-button.tsx
+++ b/components/sports/session/delete-session-button.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Trash2 } from "lucide-react";
 import { deleteSession } from "@/lib/actions/sessions";
 import {
@@ -21,9 +22,15 @@ import { colors, toastClasses } from "@/lib/styles";
 interface DeleteSessionButtonProps {
   sport: string;
   sessionId: string;
+  /** Render as a dropdown menu item instead of an icon button. */
+  asMenuItem?: boolean;
 }
 
-export default function DeleteSessionButton({ sport, sessionId }: DeleteSessionButtonProps) {
+export default function DeleteSessionButton({
+  sport,
+  sessionId,
+  asMenuItem,
+}: DeleteSessionButtonProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState(false);
@@ -46,14 +53,24 @@ export default function DeleteSessionButton({ sport, sessionId }: DeleteSessionB
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className={colors.destructiveHover}
-          title="Delete session"
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
+        {asMenuItem ? (
+          <DropdownMenuItem
+            onSelect={(e) => e.preventDefault()}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </DropdownMenuItem>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className={colors.destructiveHover}
+            title="Delete session"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>

--- a/components/sports/session/restore-session-button.tsx
+++ b/components/sports/session/restore-session-button.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { RotateCcw } from "lucide-react";
 import { restoreSession } from "@/lib/actions/sessions";
 import { colors } from "@/lib/styles";
@@ -13,12 +14,15 @@ interface RestoreSessionButtonProps {
   sessionId: string;
   /** Render an icon-only button or a full labeled button. */
   variant?: "icon" | "full";
+  /** Render as a dropdown menu item instead of a button. */
+  asMenuItem?: boolean;
 }
 
 export default function RestoreSessionButton({
   sport,
   sessionId,
   variant = "icon",
+  asMenuItem,
 }: RestoreSessionButtonProps) {
   const router = useRouter();
   const [pending, setPending] = useState(false);
@@ -36,6 +40,15 @@ export default function RestoreSessionButton({
     toast("Session restored.");
     router.refresh();
   };
+
+  if (asMenuItem) {
+    return (
+      <DropdownMenuItem onClick={handleRestore} disabled={pending}>
+        <RotateCcw className="h-4 w-4 mr-2" />
+        Restore
+      </DropdownMenuItem>
+    );
+  }
 
   if (variant === "icon") {
     return (

--- a/components/sports/session/session-form.tsx
+++ b/components/sports/session/session-form.tsx
@@ -179,7 +179,7 @@ export default function SessionForm({
         <Label htmlFor="session_type">Session Type</Label>
         <Select value={sessionType} onValueChange={(v) => setSessionType(v)}>
           <SelectTrigger id="session_type">
-            <SelectValue />
+            <SelectValue placeholder="Select a session type" />
           </SelectTrigger>
           <SelectContent>
             {sessionTabs.map((tab) => (

--- a/components/sports/session/session-tab-pills.tsx
+++ b/components/sports/session/session-tab-pills.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cn } from "@/lib/utils";
 
 interface TabPill {

--- a/components/ui/collapsible-section.tsx
+++ b/components/ui/collapsible-section.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleSectionProps {
+    title: string;
+    description?: string;
+    defaultOpen?: boolean;
+    className?: string;
+    children: React.ReactNode;
+}
+
+export function CollapsibleSection({
+    title,
+    description,
+    defaultOpen,
+    className,
+    children,
+}: CollapsibleSectionProps) {
+    return (
+        <Collapsible defaultOpen={defaultOpen} className={cn("rounded-lg border bg-card overflow-hidden", className)}>
+            <CollapsibleTrigger className="flex w-full items-center justify-between p-6 pb-0 group cursor-pointer data-[state=closed]:pb-6">
+                <div className="space-y-1 text-left">
+                    <h3 className="text-base font-semibold text-foreground">{title}</h3>
+                    {description && (
+                        <p className="text-sm text-muted-foreground">{description}</p>
+                    )}
+                </div>
+                <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
+            </CollapsibleTrigger>
+            <CollapsibleContent className="px-6 pb-6 space-y-4">
+                {children}
+            </CollapsibleContent>
+        </Collapsible>
+    );
+}

--- a/components/ui/collapsible-section.tsx
+++ b/components/ui/collapsible-section.tsx
@@ -6,34 +6,33 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { cn } from "@/lib/utils";
 
 interface CollapsibleSectionProps {
-    title: string;
-    description?: string;
-    defaultOpen?: boolean;
-    className?: string;
-    children: React.ReactNode;
+  title: string;
+  description?: string;
+  defaultOpen?: boolean;
+  className?: string;
+  children: React.ReactNode;
 }
 
 export function CollapsibleSection({
-    title,
-    description,
-    defaultOpen,
-    className,
-    children,
+  title,
+  description,
+  defaultOpen,
+  className,
+  children,
 }: CollapsibleSectionProps) {
-    return (
-        <Collapsible defaultOpen={defaultOpen} className={cn("rounded-lg border bg-card overflow-hidden", className)}>
-            <CollapsibleTrigger className="flex w-full items-center justify-between p-6 pb-0 group cursor-pointer data-[state=closed]:pb-6">
-                <div className="space-y-1 text-left">
-                    <h3 className="text-base font-semibold text-foreground">{title}</h3>
-                    {description && (
-                        <p className="text-sm text-muted-foreground">{description}</p>
-                    )}
-                </div>
-                <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
-            </CollapsibleTrigger>
-            <CollapsibleContent className="px-6 pb-6 space-y-4">
-                {children}
-            </CollapsibleContent>
-        </Collapsible>
-    );
+  return (
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className={cn("rounded-lg border bg-card overflow-hidden", className)}
+    >
+      <CollapsibleTrigger className="flex w-full items-center justify-between p-6 pb-0 group cursor-pointer data-[state=closed]:pb-6">
+        <div className="space-y-1 text-left">
+          <h3 className="text-base font-semibold text-foreground">{title}</h3>
+          {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        </div>
+        <ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="px-6 pb-6 space-y-4">{children}</CollapsibleContent>
+    </Collapsible>
+  );
 }


### PR DESCRIPTION
 improve admin mobile UX: card layout, sticky save bar, overflow menus, collapsable sections.

- Access requests: card layout on mobile, labeled buttons on desktop
- Settings: sticky bottom save bar, unsaved changes banner, collapsible sections
- Session accordion: overflow dropdown menu on mobile, larger touch targets
- Admin sidebar: bigger pills
- Add shared CollapsibleSection UI component
- Add asMenuItem prop to delete/cancel/restore session buttons
- Add missing 'use client' directives to 3 files
- fix create session textbox overflow
- fix when dropdown isn't selected, it shows "select a session type" instead of nothing