### PR TITLE
fix: calendar export

### DIFF
--- a/__tests__/fixtures/calendar.ts
+++ b/__tests__/fixtures/calendar.ts
@@ -1,0 +1,23 @@
+import { SESSION_STATUS, type SportSession } from "@/lib/supabase/types";
+
+export const BASE_CALENDAR_SESSION: SportSession = {
+  id: "session-1",
+  sport: "softball",
+  session_type: "umpiring",
+  title: "Umpire Crew",
+  date: "2026-06-20",
+  time_start: "18:30",
+  time_end: "20:30",
+  location_name: "Main Diamond",
+  location_address: "123 Field Rd",
+  location_maps_link: null,
+  player_cap: 2,
+  signup_open: "2026-06-10T12:00:00Z",
+  signup_close: "2026-06-20T16:00:00Z",
+  notes: null,
+  status: SESSION_STATUS.active,
+  status_notes: null,
+  alt_session_views: [],
+  created_by: null,
+  created_at: "2026-06-01T12:00:00Z",
+};

--- a/__tests__/lib/calendar-export.test.ts
+++ b/__tests__/lib/calendar-export.test.ts
@@ -42,5 +42,4 @@ describe("sessionsToIcal", () => {
     expect(ical).toContain("UID:session-active@ntcbc-sports");
     expect(ical).not.toContain("UID:session-cancelled@ntcbc-sports");
   });
-
 });

--- a/__tests__/lib/calendar-export.test.ts
+++ b/__tests__/lib/calendar-export.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { sessionsToIcal } from "@/lib/calendar-export";
+import { SESSION_STATUS, type SportSession } from "@/lib/supabase/types";
+import { BASE_CALENDAR_SESSION } from "../fixtures/calendar";
+
+describe("sessionsToIcal", () => {
+  it("includes cancelled sessions with STATUS:CANCELLED when requested", () => {
+    const cancelledSession: SportSession = {
+      ...BASE_CALENDAR_SESSION,
+      id: "session-2",
+      status: SESSION_STATUS.cancelled,
+    };
+
+    const ical = sessionsToIcal([cancelledSession], {
+      calendarName: "NTCBC Softball Sessions",
+      includeCancelled: true,
+    });
+
+    expect(ical).toContain("BEGIN:VEVENT");
+    expect(ical).toContain("UID:session-2@ntcbc-sports");
+    expect(ical).toContain("STATUS:CANCELLED");
+    expect(ical).toContain("SEQUENCE:1");
+  });
+
+  it("excludes cancelled sessions when includeCancelled is false", () => {
+    const activeSession: SportSession = {
+      ...BASE_CALENDAR_SESSION,
+      id: "session-active",
+      status: SESSION_STATUS.active,
+    };
+    const cancelledSession: SportSession = {
+      ...BASE_CALENDAR_SESSION,
+      id: "session-cancelled",
+      status: SESSION_STATUS.cancelled,
+    };
+
+    const ical = sessionsToIcal([activeSession, cancelledSession], {
+      calendarName: "NTCBC Softball Sessions",
+      includeCancelled: false,
+    });
+
+    expect(ical).toContain("UID:session-active@ntcbc-sports");
+    expect(ical).not.toContain("UID:session-cancelled@ntcbc-sports");
+  });
+
+});

--- a/__tests__/lib/calendar-export.test.ts
+++ b/__tests__/lib/calendar-export.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { sessionsToIcal } from "@/lib/calendar-export";
+import { resolveAnchoredFromDate } from "@/lib/timezone";
 import { SESSION_STATUS, type SportSession } from "@/lib/supabase/types";
 import { BASE_CALENDAR_SESSION } from "../fixtures/calendar";
 
+// ── sessionsToIcal ───────────────────────────────────────────────
+
 describe("sessionsToIcal", () => {
-  it("includes cancelled sessions with STATUS:CANCELLED when requested", () => {
+  it("includes cancelled sessions with STATUS:CANCELLED and SEQUENCE:1", () => {
     const cancelledSession: SportSession = {
       ...BASE_CALENDAR_SESSION,
       id: "session-2",
@@ -20,6 +23,16 @@ describe("sessionsToIcal", () => {
     expect(ical).toContain("UID:session-2@ntcbc-sports");
     expect(ical).toContain("STATUS:CANCELLED");
     expect(ical).toContain("SEQUENCE:1");
+  });
+
+  it("active sessions have SEQUENCE:0 and no STATUS line", () => {
+    const ical = sessionsToIcal([BASE_CALENDAR_SESSION], {
+      calendarName: "NTCBC Softball Sessions",
+      includeCancelled: true,
+    });
+
+    expect(ical).toContain("SEQUENCE:0");
+    expect(ical).not.toContain("STATUS:");
   });
 
   it("excludes cancelled sessions when includeCancelled is false", () => {
@@ -41,5 +54,32 @@ describe("sessionsToIcal", () => {
 
     expect(ical).toContain("UID:session-active@ntcbc-sports");
     expect(ical).not.toContain("UID:session-cancelled@ntcbc-sports");
+  });
+});
+
+// ── resolveAnchoredFromDate ──────────────────────────────────────
+
+describe("resolveAnchoredFromDate", () => {
+  it("returns undefined when subscribedAt is null", () => {
+    expect(resolveAnchoredFromDate(null, false)).toBeUndefined();
+  });
+
+  it("returns undefined when includeHistory is true", () => {
+    expect(resolveAnchoredFromDate("1718672400000", true)).toBeUndefined();
+  });
+
+  it("parses epoch milliseconds into a YYYY-MM-DD date", () => {
+    // 2026-06-18T00:00:00Z
+    const result = resolveAnchoredFromDate("1781827200000", false);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("parses ISO date string into a YYYY-MM-DD date", () => {
+    const result = resolveAnchoredFromDate("2026-06-18T12:00:00Z", false);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns undefined for invalid input", () => {
+    expect(resolveAnchoredFromDate("not-a-date", false)).toBeUndefined();
   });
 });

--- a/app/api/calendar/[sport]/route.ts
+++ b/app/api/calendar/[sport]/route.ts
@@ -98,7 +98,7 @@ export async function GET(
 
   const ical = sessionsToIcal(filtered, {
     calendarName,
-    includeCancelled: !isDownload,
+    includeCancelled: true,
     buildSessionUrl: (session) => getSessionUrl(origin, sport, session.id),
   });
 

--- a/app/api/calendar/[sport]/route.ts
+++ b/app/api/calendar/[sport]/route.ts
@@ -6,6 +6,7 @@ import { getSessionsWithClient } from "@/lib/get-data";
 import { sessionsToIcal } from "@/lib/calendar-export";
 import { getResolvedSportConfig } from "@/lib/get-sport-config";
 import { getSessionUrl } from "@/lib/session-route";
+import { resolveAnchoredFromDate } from "@/lib/timezone";
 import { AccessLevel } from "@/config/config-resolver";
 
 export async function GET(
@@ -20,6 +21,7 @@ export async function GET(
   const tabFilters = searchParams.getAll("tab");
   const includeHistory = searchParams.get("history") === "true";
   const includeDeclined = searchParams.get("includeDeclined") === "true";
+  const subscribedAt = searchParams.get("subscribedAt");
 
   // ── Validate sport ───────────────────────────────────────────
   const config = await getResolvedSportConfig(sport);
@@ -60,9 +62,11 @@ export async function GET(
 
   // ── Fetch sessions ───────────────────────────────────────────
   const isDownload = mode === "download";
+  const anchoredFromDate = resolveAnchoredFromDate(subscribedAt, includeHistory);
 
   const sessions = await getSessionsWithClient(supabase, sport, {
     includeHistory,
+    fromDate: anchoredFromDate,
   });
 
   // ── Filter by access + tab ───────────────────────────────────

--- a/components/sports/session/calendar-export-button.tsx
+++ b/components/sports/session/calendar-export-button.tsx
@@ -59,6 +59,9 @@ export default function CalendarExportButton({ sport, userId, tabs }: CalendarEx
     const params = new URLSearchParams();
     params.set("userId", userId);
     params.set("mode", mode);
+    if (mode === "subscribe") {
+      params.set("subscribedAt", String(Date.now()));
+    }
     if (!allSelected) {
       for (const tab of selectedTabs) {
         params.append("tab", tab);

--- a/lib/calendar-export.ts
+++ b/lib/calendar-export.ts
@@ -41,6 +41,7 @@ function buildVEvent(session: SportSession, options: CalendarExportOptions): str
   const dtStart = toIcalDateTime(session.date, session.time_start);
   const dtEnd = toIcalDateTime(session.date, session.time_end);
   const uid = `${session.id}@ntcbc-sports`;
+  const cancelled = session.status === SESSION_STATUS.cancelled;
   const summary = session.title || `${session.session_type} session`;
   const location = [session.location_name, session.location_address].filter(Boolean).join(", ");
   const sessionLink = options.buildSessionUrl?.(session) ?? null;
@@ -54,6 +55,7 @@ function buildVEvent(session: SportSession, options: CalendarExportOptions): str
     "BEGIN:VEVENT",
     `UID:${uid}`,
     `DTSTAMP:${formatUtcNow()}`,
+    `SEQUENCE:${cancelled ? 1 : 0}`,
     `DTSTART;TZID=${SPORT_TIMEZONE}:${dtStart}`,
     `DTEND;TZID=${SPORT_TIMEZONE}:${dtEnd}`,
     `SUMMARY:${escapeText(summary)}`,
@@ -62,7 +64,7 @@ function buildVEvent(session: SportSession, options: CalendarExportOptions): str
   if (location) lines.push(`LOCATION:${escapeText(location)}`);
   if (description) lines.push(`DESCRIPTION:${escapeText(description)}`);
   if (sessionLink) lines.push(`URL:${sessionLink}`);
-  if (session.status === SESSION_STATUS.cancelled) lines.push("STATUS:CANCELLED");
+  if (cancelled) lines.push("STATUS:CANCELLED");
 
   lines.push("END:VEVENT");
   return lines;

--- a/lib/get-data.ts
+++ b/lib/get-data.ts
@@ -47,12 +47,12 @@ export async function getAllSessions(sport: string) {
 export async function getSessionsWithClient(
   supabase: SupabaseClient,
   sport: string,
-  options?: { includeHistory?: boolean },
+  options?: { includeHistory?: boolean; fromDate?: string },
 ): Promise<SportSession[]> {
   let query = supabase.from("sessions").select("*").eq("sport", sport);
 
   if (!options?.includeHistory) {
-    query = query.gte("date", getTodayInSportTimezone());
+    query = query.gte("date", options?.fromDate ?? getTodayInSportTimezone());
   }
 
   const { data } = await query.order("date", { ascending: true }).returns<SportSession[]>();

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -27,3 +27,27 @@ export const SPORT_TIMEZONE = "America/Toronto";
 export function getTodayInSportTimezone(): string {
   return formatInTimeZone(new Date(), SPORT_TIMEZONE, "yyyy-MM-dd");
 }
+
+/** Formats any Date as `YYYY-MM-DD` in {@link SPORT_TIMEZONE}. */
+export function getDateInSportTimezone(date: Date): string {
+  return formatInTimeZone(date, SPORT_TIMEZONE, "yyyy-MM-dd");
+}
+
+/**
+ * Parses a subscription anchor timestamp (epoch ms or ISO string) into a
+ * `YYYY-MM-DD` sport-timezone date. Returns `undefined` when the input is
+ * missing, invalid, or history mode makes the anchor irrelevant.
+ */
+export function resolveAnchoredFromDate(
+  subscribedAt: string | null,
+  includeHistory: boolean,
+): string | undefined {
+  if (includeHistory || !subscribedAt) return undefined;
+
+  const parsedMs = Number(subscribedAt);
+  const anchorDate = Number.isFinite(parsedMs) ? new Date(parsedMs) : new Date(subscribedAt);
+
+  if (Number.isNaN(anchorDate.getTime())) return undefined;
+
+  return getDateInSportTimezone(anchorDate);
+}


### PR DESCRIPTION
- Write tests for calendar
- fix cancelled sessions should show strikethrough
- anchor calendar subscription to a date so data on each cal update API call stays consistent (eg. if user subscribed on day 2, day 1 data should not be available but day 2 data should be available when their calendar apps ping our servers for updates on day 3)