### PR TITLE
feat: show team member icon in facilitator picker and include more users in picker

### DIFF
--- a/components/sports/admin/admin-session-accordion.tsx
+++ b/components/sports/admin/admin-session-accordion.tsx
@@ -41,7 +41,7 @@ interface SessionAccordionProps {
   sessions: SportSession[];
   signupsBySession: Map<string, SessionSignupEntry[]>;
   teamMemberIds: Set<string>;
-  sportUsers?: { id: string; name: string }[];
+  sportUsers?: { id: string; name: string; isTeamMember: boolean }[];
   muted?: boolean;
 }
 

--- a/components/sports/admin/admin-tabs/create-form.tsx
+++ b/components/sports/admin/admin-tabs/create-form.tsx
@@ -17,7 +17,7 @@ interface CreateFormProps {
   sport: string;
   sessionTabs: SessionTypeOption[];
   defaultTab?: string;
-  sportUsers?: { id: string; name: string }[];
+  sportUsers?: { id: string; name: string; isTeamMember: boolean }[];
 }
 
 export default function CreateForm({
@@ -46,7 +46,7 @@ function CreateFormInner({
 }: {
   sport: string;
   sessionTabs: SessionTypeOption[];
-  sportUsers?: { id: string; name: string }[];
+  sportUsers?: { id: string; name: string; isTeamMember: boolean }[];
 }) {
   const { isDirty, discard } = useConfigurator<SessionFormState>();
   const formRef = useRef<HTMLFormElement>(null);

--- a/components/sports/session/facilitator-picker.tsx
+++ b/components/sports/session/facilitator-picker.tsx
@@ -10,7 +10,7 @@ interface FacilitatorPickerProps {
   sport: string;
   sessionId: string;
   currentFacilitatorId: string | null;
-  sportUsers: { id: string; name: string }[];
+  sportUsers: { id: string; name: string; isTeamMember: boolean }[];
 }
 
 /**

--- a/components/sports/session/facilitator-select.tsx
+++ b/components/sports/session/facilitator-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Check, ChevronsUpDown, UserRoundPlus } from "lucide-react";
+import { Check, ChevronsUpDown, Shield, UserRoundPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 export interface FacilitatorSelectProps {
   value: string | null;
   onChange: (userId: string | null) => void;
-  users: { id: string; name: string }[];
+  users: { id: string; name: string; isTeamMember: boolean }[];
   disabled?: boolean;
   /** Render as full-width trigger (for forms) vs compact button (for inline). */
   fullWidth?: boolean;
@@ -97,6 +97,12 @@ export function FacilitatorSelect({
                       onSelect={() => handleSelect(current.id)}
                     >
                       <Check className="h-4 w-4 mr-2 opacity-100" />
+                      <Shield
+                        className={cn(
+                          "h-3.5 w-3.5 mr-1.5 shrink-0",
+                          current.isTeamMember ? "text-muted-foreground" : "invisible",
+                        )}
+                      />
                       {current.name}
                     </CommandItem>
                   ) : null;
@@ -114,6 +120,12 @@ export function FacilitatorSelect({
                     onSelect={() => handleSelect(user.id)}
                   >
                     <Check className="h-4 w-4 mr-2 opacity-0" />
+                    <Shield
+                      className={cn(
+                        "h-3.5 w-3.5 mr-1.5 shrink-0",
+                        user.isTeamMember ? "text-muted-foreground" : "invisible",
+                      )}
+                    />
                     {user.name}
                   </CommandItem>
                 ))}

--- a/components/sports/session/session-form.tsx
+++ b/components/sports/session/session-form.tsx
@@ -34,7 +34,7 @@ interface SessionFormProps {
   sport: string;
   sessionTabs: SessionTypeOption[];
   session?: SportSession;
-  sportUsers?: { id: string; name: string }[];
+  sportUsers?: { id: string; name: string; isTeamMember: boolean }[];
   onSuccess?: () => void;
   formRef?: RefObject<HTMLFormElement | null>;
   onPendingChange?: (pending: boolean) => void;
@@ -447,7 +447,7 @@ interface SessionFormDialogProps {
   sessionTabs: SessionTypeOption[];
   defaultTab?: string;
   session?: SportSession;
-  sportUsers?: { id: string; name: string }[];
+  sportUsers?: { id: string; name: string; isTeamMember: boolean }[];
   trigger?: ReactNode;
 }
 

--- a/lib/get-data.ts
+++ b/lib/get-data.ts
@@ -123,21 +123,39 @@ export async function getTeamMembers(sport: string) {
   return new Set((data ?? []).map((m) => m.user_id));
 }
 
-/** Users with a sport_role for a sport (for facilitator dropdown). */
+/** Users with a sport_role OR signup for a sport (for facilitator dropdown). */
 export async function getSportUsers(sport: string) {
   const supabase = await createClient();
-  const { data } = await supabase
+
+  // Users with an explicit sport_role
+  const { data: roleData } = await supabase
     .from("sport_roles")
-    .select("user_id, profiles!sport_roles_user_id_fkey(id, full_name, email)")
+    .select("user_id, is_team_member, profiles!sport_roles_user_id_fkey(id, full_name, email)")
     .eq("sport", sport);
 
-  return (data ?? [])
-    .map((r) => {
-      const p = r.profiles as unknown as Profile | null;
-      return p ? { id: p.id, name: p.full_name ?? p.email } : null;
-    })
-    .filter((u): u is { id: string; name: string } => u !== null)
-    .sort((a, b) => a.name.localeCompare(b.name));
+  // Users who signed up for any session in this sport (may not have a sport_role)
+  const { data: signupData } = await supabase
+    .from("signups")
+    .select("user_id, profiles(id, full_name, email), sessions!inner(sport)")
+    .eq("sessions.sport", sport);
+
+  const userMap = new Map<string, { id: string; name: string; isTeamMember: boolean }>();
+
+  for (const r of roleData ?? []) {
+    const p = r.profiles as unknown as Profile | null;
+    if (p) {
+      userMap.set(p.id, { id: p.id, name: p.full_name ?? p.email, isTeamMember: r.is_team_member });
+    }
+  }
+
+  for (const s of signupData ?? []) {
+    const p = s.profiles as unknown as Profile | null;
+    if (p && !userMap.has(p.id)) {
+      userMap.set(p.id, { id: p.id, name: p.full_name ?? p.email, isTeamMember: false });
+    }
+  }
+
+  return [...userMap.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /** Current user's access request status for a sport. */


### PR DESCRIPTION
- getSportUsers() now returns isTeamMember flag and includes users from signups who may not have a sport_role entry
- FacilitatorSelect renders Shield icon (visible for team members, invisible spacer for others) for consistent alignment
- Updated prop types across facilitator-picker, session-form, admin-session-accordion, and create-form