### PR TITLE
fix: await calendar tracking upsert (Vercel kills fire-and-forget)

### DIFF
--- a/__tests__/ui/calendar-usage-compute.test.ts
+++ b/__tests__/ui/calendar-usage-compute.test.ts
@@ -27,7 +27,7 @@ describe("computeCalendarStats", () => {
     expect(result.activeSubscribers).toBe(0);
     expect(result.totalDownloaders).toBe(0);
     expect(result.uniqueUsers).toBe(0);
-    expect(result.rows).toHaveLength(0);
+    expect(result.users).toHaveLength(0);
   });
 
   it("counts subscribers and downloaders separately", () => {
@@ -69,7 +69,7 @@ describe("computeCalendarStats", () => {
     expect(result.activeSubscribers).toBe(1);
   });
 
-  it("sorts rows by most recent activity first", () => {
+  it("sorts users by most recent activity first", () => {
     const rows = [
       makeCalendarRow({
         userId: "u1",
@@ -84,8 +84,8 @@ describe("computeCalendarStats", () => {
     ];
 
     const result = computeCalendarStats(rows);
-    expect(result.rows[0]!.userName).toBe("Newer");
-    expect(result.rows[1]!.userName).toBe("Older");
+    expect(result.users[0]!.userName).toBe("Newer");
+    expect(result.users[1]!.userName).toBe("Older");
   });
 
   it("does not mutate the original array", () => {
@@ -99,7 +99,7 @@ describe("computeCalendarStats", () => {
     expect(rows[0]).toBe(originalFirst);
   });
 
-  it("handles a user with both subscribe and download as separate entries", () => {
+  it("groups a user with both subscribe and download into one entry", () => {
     const rows = [
       makeCalendarRow({ userId: "u1", userName: "Alice", mode: "subscribe" }),
       makeCalendarRow({ userId: "u1", userName: "Alice", mode: "download" }),
@@ -108,8 +108,11 @@ describe("computeCalendarStats", () => {
     const result = computeCalendarStats(rows);
     expect(result.totalSubscribers).toBe(1);
     expect(result.totalDownloaders).toBe(1);
-    expect(result.uniqueUsers).toBe(1); // same user, counted once
-    expect(result.rows).toHaveLength(2); // but both entries shown in table
+    expect(result.uniqueUsers).toBe(1);
+    expect(result.users).toHaveLength(1); // one user row
+    expect(result.users[0]!.entries).toHaveLength(2); // both modes as entries
+    expect(result.users[0]!.entries[0]!.mode).toBe("subscribe"); // subscribe first
+    expect(result.users[0]!.entries[1]!.mode).toBe("download");
   });
 
   it("boundary: subscriber active exactly 7 days ago is not active", () => {

--- a/app/api/calendar/[sport]/route.ts
+++ b/app/api/calendar/[sport]/route.ts
@@ -106,12 +106,13 @@ export async function GET(
     buildSessionUrl: (session) => getSessionUrl(origin, sport, session.id),
   });
 
-  // Fire-and-forget: track subscription access (not downloads — those are tracked client-side).
+  // Track subscription access — awaited because Vercel terminates the function
+  // after the response is sent, so fire-and-forget promises won't complete.
   // PK is (user_id, sport, mode) so subscribe/download are independent rows per user.
   // created_at is intentionally excluded — DB default sets it on first INSERT,
   // and PostgREST only updates payload columns on conflict, preserving the original timestamp.
   if (!isDownload) {
-    void supabase.from("calendar_tracking").upsert(
+    await supabase.from("calendar_tracking").upsert(
       {
         user_id: userId,
         sport,

--- a/components/sports/statistics/components/calendar-usage-section.tsx
+++ b/components/sports/statistics/components/calendar-usage-section.tsx
@@ -1,5 +1,5 @@
 import { CalendarDays, Rss, Download, TrendingUp, TrendingDown } from "lucide-react";
-import type { CalendarStats, CalendarCorrelation } from "../compute";
+import type { CalendarStats, CalendarCorrelation, CalendarUserEntry } from "../compute";
 
 interface CalendarUsageSectionProps {
   stats: CalendarStats;
@@ -24,28 +24,29 @@ export default function CalendarUsageSection({
 
   // Personal mode: compact view of user's own calendar status
   if (isPersonal) {
+    const entries = stats.users.flatMap((u) => u.entries);
     return (
       <div className="space-y-3 pt-4">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {stats.rows.map((row, i) => (
+          {entries.map((entry, i) => (
             <div key={i} className="rounded-lg border bg-card p-3">
               <div className="flex items-center gap-2">
-                {row.mode === "subscribe" ? (
+                {entry.mode === "subscribe" ? (
                   <Rss className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                 ) : (
                   <Download className="h-4 w-4 text-green-600 dark:text-green-400" />
                 )}
                 <p className="text-sm font-medium text-foreground">
-                  {row.mode === "subscribe" ? "Calendar Subscription" : "Calendar Download"}
+                  {entry.mode === "subscribe" ? "Calendar Subscription" : "Calendar Download"}
                 </p>
               </div>
               <div className="mt-2 space-y-1">
                 <p className="text-xs text-muted-foreground">
-                  First used: <span className="text-foreground">{formatDate(row.createdAt)}</span>
+                  First used: <span className="text-foreground">{formatDate(entry.createdAt)}</span>
                 </p>
                 <p className="text-xs text-muted-foreground">
                   Last active:{" "}
-                  <span className="text-foreground">{formatRelative(row.lastUsedAt)}</span>
+                  <span className="text-foreground">{formatRelative(entry.lastUsedAt)}</span>
                 </p>
               </div>
             </div>
@@ -107,31 +108,27 @@ export default function CalendarUsageSection({
             </tr>
           </thead>
           <tbody className="divide-y">
-            {stats.rows.map((row, i) => (
-              <tr key={i} className="hover:bg-muted/30">
-                <td className="px-3 py-2 text-foreground">{row.userName}</td>
-                <td className="px-3 py-2">
-                  <span
-                    className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded ${
-                      row.mode === "subscribe"
-                        ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-                        : "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300"
-                    }`}
-                  >
-                    {row.mode === "subscribe" ? (
-                      <Rss className="h-3 w-3" />
-                    ) : (
-                      <Download className="h-3 w-3" />
-                    )}
-                    {row.mode === "subscribe" ? "Subscription" : "Download"}
-                  </span>
-                </td>
-                <td className="px-3 py-2 text-muted-foreground">{formatDate(row.createdAt)}</td>
-                <td className="px-3 py-2 text-muted-foreground">
-                  {formatRelative(row.lastUsedAt)}
-                </td>
-              </tr>
-            ))}
+            {stats.users.map((user) =>
+              user.entries.map((entry, entryIdx) => (
+                <tr key={`${user.userName}-${entry.mode}`} className="hover:bg-muted/30">
+                  {entryIdx === 0 && (
+                    <td
+                      className="px-3 py-2 text-foreground align-top"
+                      rowSpan={user.entries.length}
+                    >
+                      {user.userName}
+                    </td>
+                  )}
+                  <td className="px-3 py-2">
+                    <ModeBadge entry={entry} />
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{formatDate(entry.createdAt)}</td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {formatRelative(entry.lastUsedAt)}
+                  </td>
+                </tr>
+              )),
+            )}
           </tbody>
         </table>
       </div>
@@ -195,6 +192,21 @@ function CorrelationInsight({ correlation }: { correlation: CalendarCorrelation 
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
+
+function ModeBadge({ entry }: { entry: CalendarUserEntry }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded ${
+        entry.mode === "subscribe"
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+          : "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-300"
+      }`}
+    >
+      {entry.mode === "subscribe" ? <Rss className="h-3 w-3" /> : <Download className="h-3 w-3" />}
+      {entry.mode === "subscribe" ? "Subscription" : "Download"}
+    </span>
+  );
+}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {

--- a/components/sports/statistics/components/calendar-usage-section.tsx
+++ b/components/sports/statistics/components/calendar-usage-section.tsx
@@ -107,29 +107,29 @@ export default function CalendarUsageSection({
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y">
-            {stats.users.map((user) =>
-              user.entries.map((entry, entryIdx) => (
-                <tr key={`${user.userName}-${entry.mode}`} className="hover:bg-muted/30">
-                  {entryIdx === 0 && (
+          {stats.users.map((user) => (
+            <tbody key={user.userName} className="border-t hover:bg-muted/30">
+              {user.entries.map((entry, entryIdx) => (
+                <tr key={entry.mode}>
+                  {entryIdx === 0 ? (
                     <td
                       className="px-3 py-2 text-foreground align-top"
                       rowSpan={user.entries.length}
                     >
                       {user.userName}
                     </td>
-                  )}
+                  ) : null}
                   <td className="px-3 py-2">
                     <ModeBadge entry={entry} />
                   </td>
                   <td className="px-3 py-2 text-muted-foreground">{formatDate(entry.createdAt)}</td>
-                  <td className="px-3 py-2 text-muted-foreground">
-                    {formatRelative(entry.lastUsedAt)}
+                  <td className="px-3 py-2">
+                    <LastActive iso={entry.lastUsedAt} />
                   </td>
                 </tr>
-              )),
-            )}
-          </tbody>
+              ))}
+            </tbody>
+          ))}
         </table>
       </div>
     </div>
@@ -204,6 +204,17 @@ function ModeBadge({ entry }: { entry: CalendarUserEntry }) {
     >
       {entry.mode === "subscribe" ? <Rss className="h-3 w-3" /> : <Download className="h-3 w-3" />}
       {entry.mode === "subscribe" ? "Subscription" : "Download"}
+    </span>
+  );
+}
+
+function LastActive({ iso }: { iso: string }) {
+  const diffDays = Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
+  const isStale = diffDays >= 7;
+
+  return (
+    <span className={isStale ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}>
+      {formatRelative(iso)}
     </span>
   );
 }

--- a/components/sports/statistics/compute.ts
+++ b/components/sports/statistics/compute.ts
@@ -491,11 +491,12 @@ export function computeCalendarStats(rows: CalendarUsageRow[]): CalendarStats {
   }
 
   // Sort users by most recent activity first; within each user sort entries subscribe-first
+  const modeOrder = { subscribe: 0, download: 1 } as const;
   const users = [...userMap.values()]
     .sort((a, b) => b.latestActivity.localeCompare(a.latestActivity))
     .map((u) => ({
       ...u,
-      entries: u.entries.sort((a, b) => (a.mode === "subscribe" ? -1 : 1)),
+      entries: u.entries.sort((a, b) => modeOrder[a.mode] - modeOrder[b.mode]),
     }));
 
   return {

--- a/components/sports/statistics/compute.ts
+++ b/components/sports/statistics/compute.ts
@@ -417,18 +417,28 @@ export function computePlayerStats(
 
 // ── Calendar usage stats ─────────────────────────────────────────
 
+export interface CalendarUserEntry {
+  mode: "subscribe" | "download";
+  createdAt: string;
+  lastUsedAt: string;
+}
+
+export interface CalendarUserRow {
+  userName: string;
+  /** All modes this user has used (1 or 2 entries). Sorted subscribe-first. */
+  entries: CalendarUserEntry[];
+  /** Most recent activity across all modes — used for sorting. */
+  latestActivity: string;
+}
+
 export interface CalendarStats {
   totalSubscribers: number;
   activeSubscribers: number;
   totalDownloaders: number;
   /** Count of unique users who have used either subscribe or download. */
   uniqueUsers: number;
-  rows: Array<{
-    userName: string;
-    mode: "subscribe" | "download";
-    createdAt: string;
-    lastUsedAt: string;
-  }>;
+  /** Grouped by user — each user appears once with all their mode entries. */
+  users: CalendarUserRow[];
 }
 
 /**
@@ -444,32 +454,56 @@ export function computeCalendarStats(rows: CalendarUsageRow[]): CalendarStats {
   let totalSubscribers = 0;
   let activeSubscribers = 0;
   let totalDownloaders = 0;
-  const userIds = new Set<string>();
+
+  // Group by userId
+  const userMap = new Map<
+    string,
+    { userName: string; entries: CalendarUserEntry[]; latestActivity: string }
+  >();
 
   for (const row of rows) {
-    userIds.add(row.userId);
     if (row.mode === "subscribe") {
       totalSubscribers++;
       if (row.lastUsedAt >= cutoff) activeSubscribers++;
     } else {
       totalDownloaders++;
     }
+
+    const existing = userMap.get(row.userId);
+    const entry: CalendarUserEntry = {
+      mode: row.mode,
+      createdAt: row.createdAt,
+      lastUsedAt: row.lastUsedAt,
+    };
+
+    if (existing) {
+      existing.entries.push(entry);
+      if (row.lastUsedAt > existing.latestActivity) {
+        existing.latestActivity = row.lastUsedAt;
+      }
+    } else {
+      userMap.set(row.userId, {
+        userName: row.userName,
+        entries: [entry],
+        latestActivity: row.lastUsedAt,
+      });
+    }
   }
 
-  // Sort by most recent activity first
-  const sorted = [...rows].sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt));
+  // Sort users by most recent activity first; within each user sort entries subscribe-first
+  const users = [...userMap.values()]
+    .sort((a, b) => b.latestActivity.localeCompare(a.latestActivity))
+    .map((u) => ({
+      ...u,
+      entries: u.entries.sort((a, b) => (a.mode === "subscribe" ? -1 : 1)),
+    }));
 
   return {
     totalSubscribers,
     activeSubscribers,
     totalDownloaders,
-    uniqueUsers: userIds.size,
-    rows: sorted.map((r) => ({
-      userName: r.userName,
-      mode: r.mode,
-      createdAt: r.createdAt,
-      lastUsedAt: r.lastUsedAt,
-    })),
+    uniqueUsers: userMap.size,
+    users,
   };
 }
 


### PR DESCRIPTION
void/fire-and-forget doesn't work on Vercel serverless — the function terminates after returning the response before the promise resolves. Await the upsert so the tracking write completes.