### PR TITLE
fix: stats engagement count mismatch & calendar table mobile scroll

### DIFF
--- a/components/sports/statistics/components/calendar-usage-section.tsx
+++ b/components/sports/statistics/components/calendar-usage-section.tsx
@@ -89,8 +89,8 @@ export default function CalendarUsageSection({
       {correlation && <CorrelationInsight correlation={correlation} />}
 
       {/* User list */}
-      <div className="rounded-lg border overflow-hidden">
-        <table className="w-full text-sm">
+      <div className="rounded-lg border overflow-auto -mx-4 px-0 sm:mx-0">
+        <table className="w-full text-sm min-w-[480px]">
           <thead className="bg-muted/50">
             <tr>
               <th className="text-left px-3 py-2 text-xs font-medium text-muted-foreground">
@@ -203,7 +203,9 @@ function ModeBadge({ entry }: { entry: CalendarUserEntry }) {
       }`}
     >
       {entry.mode === "subscribe" ? <Rss className="h-3 w-3" /> : <Download className="h-3 w-3" />}
-      {entry.mode === "subscribe" ? "Subscription" : "Download"}
+      <span className="hidden sm:inline">
+        {entry.mode === "subscribe" ? "Subscription" : "Download"}
+      </span>
     </span>
   );
 }

--- a/components/sports/statistics/components/calendar-usage-section.tsx
+++ b/components/sports/statistics/components/calendar-usage-section.tsx
@@ -60,8 +60,8 @@ export default function CalendarUsageSection({
   return (
     <div className="space-y-4 pt-4">
       {/* Summary cards */}
-      <div className="grid grid-cols-3 gap-3">
-        <div className="rounded-lg border bg-card p-3">
+      <div className="grid grid-cols-3 gap-2 sm:gap-3">
+        <div className="rounded-lg border bg-card p-2 sm:p-3">
           <div className="flex items-center gap-1.5">
             <Rss className="h-3.5 w-3.5 text-muted-foreground" />
             <p className="text-xs text-muted-foreground">Active Subscribers</p>
@@ -69,14 +69,14 @@ export default function CalendarUsageSection({
           <p className="text-xl font-bold text-foreground mt-1">{stats.activeSubscribers}</p>
           <p className="text-[11px] text-muted-foreground">{stats.totalSubscribers} total</p>
         </div>
-        <div className="rounded-lg border bg-card p-3">
+        <div className="rounded-lg border bg-card p-2 sm:p-3">
           <div className="flex items-center gap-1.5">
             <Download className="h-3.5 w-3.5 text-muted-foreground" />
             <p className="text-xs text-muted-foreground">Downloads</p>
           </div>
           <p className="text-xl font-bold text-foreground mt-1">{stats.totalDownloaders}</p>
         </div>
-        <div className="rounded-lg border bg-card p-3">
+        <div className="rounded-lg border bg-card p-2 sm:p-3">
           <div className="flex items-center gap-1.5">
             <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
             <p className="text-xs text-muted-foreground">Total Users</p>
@@ -90,19 +90,19 @@ export default function CalendarUsageSection({
 
       {/* User list */}
       <div className="rounded-lg border overflow-auto -mx-4 px-0 sm:mx-0">
-        <table className="w-full text-sm min-w-[480px]">
+        <table className="w-full text-xs min-w-[400px]">
           <thead className="bg-muted/50">
             <tr>
-              <th className="text-left px-3 py-2 text-xs font-medium text-muted-foreground">
+              <th className="text-left px-2 sm:px-3 py-1.5 text-xs font-medium text-muted-foreground">
                 User
               </th>
-              <th className="text-left px-3 py-2 text-xs font-medium text-muted-foreground">
+              <th className="text-left px-2 sm:px-3 py-1.5 text-xs font-medium text-muted-foreground">
                 Type
               </th>
-              <th className="text-left px-3 py-2 text-xs font-medium text-muted-foreground">
+              <th className="text-left px-2 sm:px-3 py-1.5 text-xs font-medium text-muted-foreground">
                 First Used
               </th>
-              <th className="text-left px-3 py-2 text-xs font-medium text-muted-foreground">
+              <th className="text-left px-2 sm:px-3 py-1.5 text-xs font-medium text-muted-foreground">
                 Last Active
               </th>
             </tr>
@@ -113,17 +113,19 @@ export default function CalendarUsageSection({
                 <tr key={entry.mode}>
                   {entryIdx === 0 ? (
                     <td
-                      className="px-3 py-2 text-foreground align-top"
+                      className="pl-2 pr-1 sm:px-3 py-1.5 text-foreground align-top truncate max-w-[80px] sm:max-w-[140px]"
                       rowSpan={user.entries.length}
                     >
                       {user.userName}
                     </td>
                   ) : null}
-                  <td className="px-3 py-2">
+                  <td className="px-2 sm:px-3 py-1.5">
                     <ModeBadge entry={entry} />
                   </td>
-                  <td className="px-3 py-2 text-muted-foreground">{formatDate(entry.createdAt)}</td>
-                  <td className="px-3 py-2">
+                  <td className="px-2 sm:px-3 py-1.5 text-muted-foreground">
+                    {formatDate(entry.createdAt)}
+                  </td>
+                  <td className="px-2 sm:px-3 py-1.5">
                     <LastActive iso={entry.lastUsedAt} />
                   </td>
                 </tr>

--- a/lib/get-statistics.ts
+++ b/lib/get-statistics.ts
@@ -56,9 +56,10 @@ export async function getStatsData(sport: string, userId?: string): Promise<Stat
   let signupsQuery = supabase
     .from("signups")
     .select(
-      "user_id, session_id, sessions!inner(sport, date, session_type, player_cap), profiles(full_name, email)",
+      "user_id, session_id, sessions!inner(sport, date, session_type, player_cap, status), profiles(full_name, email)",
     )
     .eq("sessions.sport", sport)
+    .eq("sessions.status", "active")
     .lte("sessions.date", today)
     .in("status", ["confirmed", "waitlisted"]);
 

--- a/scripts/sync-ccsa-games.ts
+++ b/scripts/sync-ccsa-games.ts
@@ -16,9 +16,11 @@ import { loadEnvConfig } from "@next/env";
 loadEnvConfig(process.cwd());
 
 import { createClient } from "@supabase/supabase-js";
+import { fromZonedTime } from "date-fns-tz";
 import { ensureAuth } from "./ccsa-test-client";
 import { sched, team } from "../lib/softball/ccsa-api";
 import type { ScheduleGame } from "../lib/softball/ccsa-types";
+import { SPORT_TIMEZONE } from "../lib/timezone";
 
 const SPORT = "softball";
 const GAME_DURATION_HOURS = 2;
@@ -151,7 +153,7 @@ async function run(email: string) {
     // signup_close = game start time
     // game.time may be "HH:MM" or "HH:MM:SS" — normalize to HH:MM:SS
     const timeForParse = game.time.length <= 5 ? `${game.time}:00` : game.time;
-    const signupClose = new Date(`${game.date}T${timeForParse}-04:00`);
+    const signupClose = fromZonedTime(`${game.date}T${timeForParse}`, SPORT_TIMEZONE);
 
     const isHome = game.home === teamId;
     const opponent = isHome ? game.away_name : game.home_name;


### PR DESCRIPTION
- Add sessions.status='active' filter to signups query in get-statistics so cancelled sessions don't inflate attendance numerator (fixes 5/4 bug)
- Fix calendar usage table: add overflow-auto + min-width for horizontal scroll
- Hide Subscription/Download text on mobile, keep icons only
- Replace hardcoded -04:00 offset in sync script with date-fns-tz