### PR TITLE
fix: improve All tab access banner clarity for non-team members

### DIFF
--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -233,6 +233,12 @@ async function SportSessionsContent({
     const label =
       restrictedTabs.length === 1 ? restrictedTabs[0]!.tab.label.toLowerCase() : "some sessions";
 
+    const unrestrictedTabs = tabAccess.filter((a) => a.unmetLevel === null);
+    const unrestrictedLabel =
+      unrestrictedTabs.length > 2
+        ? "other sessions"
+        : unrestrictedTabs.map((a) => a.tab.label.toLowerCase()).join(" and ");
+
     if (!userId) {
       return <SignInToSignupBanner title={text.title(label)} message={text.message(label)} />;
     }
@@ -242,7 +248,7 @@ async function SportSessionsContent({
         requestStatus={accessRequestStatus}
         sport={sport}
         label={label}
-        bannerMessage={text.message(label)}
+        bannerMessage={`You can still sign up for ${unrestrictedLabel} without membership.`}
       />
     );
   })();

--- a/components/sports/signup/team-access-banner.tsx
+++ b/components/sports/signup/team-access-banner.tsx
@@ -109,7 +109,7 @@ export default function TeamAccessBanner({
     <StatusBanner
       variant="info"
       icon={<Shield className="h-5 w-5 text-info shrink-0 mt-0.5" />}
-      title="Membership required"
+      title={`Membership required for ${restrictedLabels}`}
       message={
         <>
           {bannerMessage || (


### PR DESCRIPTION
- Replace saying membership required to membership required for some sessions but you can sign up for some other sessions