### PR TITLE
fix: mobile polish, sakura rename (and migrate users)

### DIFF
--- a/__tests__/config/client-migrations.test.ts
+++ b/__tests__/config/client-migrations.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { CLIENT_MIGRATIONS } from "@/lib/client-migrations";
+
+describe("CLIENT_MIGRATIONS", () => {
+  it("has no expired migrations", () => {
+    const now = new Date();
+    const expired = CLIENT_MIGRATIONS.filter((m) => new Date(m.expiresAt) < now);
+
+    if (expired.length > 0) {
+      const ids = expired.map((m) => `"${m.id}" (expired ${m.expiresAt})`).join(", ");
+      expect.fail(`Remove expired client migrations: ${ids}`);
+    }
+  });
+
+  it("each migration has a valid structure", () => {
+    for (const m of CLIENT_MIGRATIONS) {
+      expect(m.id).toBeTruthy();
+      expect(m.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(m.script).toBeTruthy();
+    }
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,7 +167,7 @@
   --status-info-border: oklch(0.4 0.07 250);
 }
 
-.cherry-blossom {
+.sakura {
   --background: oklch(0.98 0.015 330);
   --foreground: oklch(0.2 0.05 320);
   --card: oklch(0.99 0.008 325);
@@ -235,7 +235,7 @@
   }
 }
 
-/* Cherry Blossom theme — glitter shimmer effect */
+/* Sakura theme — glitter shimmer effect */
 @keyframes cherry-shimmer {
   0% {
     background-position: -200% center;
@@ -245,7 +245,7 @@
   }
 }
 
-.cherry-blossom .cherry-glitter {
+.sakura .sakura-glitter {
   background-image: linear-gradient(
     110deg,
     transparent 25%,
@@ -258,7 +258,7 @@
   animation: cherry-shimmer 3s ease-in-out infinite;
 }
 
-/* Floating petal decorations for cherry blossom theme */
+/* Floating petal decorations for sakura theme */
 @keyframes petal-fall {
   0% {
     transform: translateY(-10%) rotate(0deg);
@@ -276,7 +276,7 @@
   }
 }
 
-.cherry-blossom .petal {
+.sakura .petal {
   position: fixed;
   pointer-events: none;
   z-index: 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
-import { CherryBlossomDecor } from "@/components/cherry-blossom-decor";
+import { SakuraDecor } from "@/components/sakura-decor";
+import { getClientMigrationScript } from "@/lib/client-migrations";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,16 +29,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <script dangerouslySetInnerHTML={{ __html: getClientMigrationScript() }} />
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"
           enableSystem
-          themes={["light", "dark", "cherry-blossom", "system"]}
+          themes={["light", "dark", "sakura", "system"]}
+          value={{
+            light: "light",
+            dark: "dark",
+            sakura: "sakura",
+          }}
           disableTransitionOnChange
         >
           <div className="min-h-screen bg-background">
-            <CherryBlossomDecor />
+            <SakuraDecor />
             <div className="container mx-auto px-4 py-8">{children}</div>
           </div>
           <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,12 +16,12 @@ export default async function Home() {
 
   return (
     <div className="max-w-4xl mx-auto mb-12 space-y-8 pt-4">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-between gap-3">
         <h1 className="text-4xl font-bold text-foreground flex items-center gap-3">
           <Image src="/favicon.ico" alt="NTCBC" width={36} height={36} className="rounded-sm" />
           NTCBC Signups
         </h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 self-end sm:self-auto">
           <ThemeToggle />
           <AuthButton user={user} />
         </div>

--- a/components/sakura-decor.tsx
+++ b/components/sakura-decor.tsx
@@ -15,12 +15,14 @@ interface Petal {
   size: number;
 }
 
-export function CherryBlossomDecor() {
-  const { theme } = useTheme();
+export function SakuraDecor() {
+  const { resolvedTheme } = useTheme();
   const [petals, setPetals] = useState<Petal[]>([]);
 
+  const isSakura = resolvedTheme === "sakura";
+
   useEffect(() => {
-    if (theme !== "cherry-blossom") {
+    if (!isSakura) {
       setPetals([]);
       return;
     }
@@ -34,19 +36,19 @@ export function CherryBlossomDecor() {
       size: 0.7 + Math.random() * 0.6,
     }));
     setPetals(generated);
-  }, [theme]);
+  }, [isSakura]);
 
-  if (theme !== "cherry-blossom" || petals.length === 0) return null;
+  if (!isSakura || petals.length === 0) return null;
 
   return (
     <>
       {/* Side glitter strips */}
       <div
-        className="cherry-glitter fixed left-0 top-0 h-full w-3 pointer-events-none z-0"
+        className="sakura-glitter fixed left-0 top-0 h-full w-3 pointer-events-none z-0"
         style={{ opacity: 0.18 }}
       />
       <div
-        className="cherry-glitter fixed right-0 top-0 h-full w-3 pointer-events-none z-0"
+        className="sakura-glitter fixed right-0 top-0 h-full w-3 pointer-events-none z-0"
         style={{ opacity: 0.18 }}
       />
       {/* Floating petals */}

--- a/components/sports/session/edit-views-dialog.tsx
+++ b/components/sports/session/edit-views-dialog.tsx
@@ -113,8 +113,8 @@ export default function EditViewsDialog({
       )}
       trigger={
         <Button variant="outline" size="sm" className="text-xs h-7">
-          <Pencil className="h-3 w-3 mr-1" />
-          Views
+          <Pencil className="h-3 w-3 sm:mr-1" />
+          <span className="hidden sm:inline">Edit</span>
         </Button>
       }
     >

--- a/components/sports/session/session-view-section.tsx
+++ b/components/sports/session/session-view-section.tsx
@@ -7,7 +7,7 @@ import ViewToggle from "@/components/sports/session/view-toggle";
 import EditViewsDialog from "@/components/sports/session/edit-views-dialog";
 import type { EditViewsDialogHandle } from "@/components/sports/session/edit-views-dialog";
 import { Button } from "@/components/ui/button";
-import { Link as LinkIcon, Pencil, Plus } from "lucide-react";
+import { BookOpen, Link as LinkIcon, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { getSessionView } from "@/components/sports/session/session-views/registry";
 import { displayName } from "@/lib/format";
@@ -90,8 +90,8 @@ export default function SessionViewSection({
         className="text-xs h-7"
         onClick={() => editViewsRef.current?.openToType("devotionalView")}
       >
-        {hasDevo ? <Pencil className="h-3 w-3 mr-1" /> : <Plus className="h-3 w-3 mr-1" />}
-        {"Devo"}
+        {hasDevo ? <BookOpen className="h-3 w-3 sm:mr-1" /> : <Plus className="h-3 w-3 sm:mr-1" />}
+        <span className="hidden sm:inline">Devo</span>
       </Button>
       <EditViewsDialog
         ref={editViewsRef}

--- a/components/sports/session/session-views/devotional-view/devotional-view.tsx
+++ b/components/sports/session/session-views/devotional-view/devotional-view.tsx
@@ -142,11 +142,25 @@ export default function DevotionalView({ viewData, isSessionAdmin: isAdmin }: Se
 
   return (
     <div className="space-y-4">
-      {/* Header row: title + facilitator toggle */}
+      {/* Mobile: toggle on its own row above title; Desktop: inline with title */}
+      {isAdmin && (
+        <div className="flex justify-end sm:hidden">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <span className="text-xs text-muted-foreground">
+              {facilitatorView ? "Facilitator View" : "Player View"}
+            </span>
+            <Switch
+              checked={facilitatorView}
+              onCheckedChange={setFacilitatorView}
+              aria-label="Toggle between facilitator and player view"
+            />
+          </label>
+        </div>
+      )}
       <div className="flex items-center justify-between gap-3">
         {data.title && <h2 className="font-bold text-lg text-foreground">{data.title}</h2>}
         {isAdmin && (
-          <label className="flex items-center gap-2 shrink-0 cursor-pointer">
+          <label className="hidden sm:flex items-center gap-2 shrink-0 cursor-pointer">
             <span className="text-xs text-muted-foreground">
               {facilitatorView ? "Facilitator View" : "Player View"}
             </span>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -21,9 +21,11 @@ import {
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [_mounted, setMounted] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
 
   return (
     <DropdownMenu>
@@ -49,11 +51,11 @@ export function ThemeToggle() {
           Dark
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => setTheme("cherry-blossom")}
-          className={theme === "cherry-blossom" ? "bg-status-info" : ""}
+          onClick={() => setTheme("sakura")}
+          className={theme === "sakura" ? "bg-status-info" : ""}
         >
           <Flower2 className="h-4 w-4 mr-2" />
-          Cherry Blossom
+          Sakura
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => setTheme("system")}

--- a/components/ui/scrollable-pills.tsx
+++ b/components/ui/scrollable-pills.tsx
@@ -49,7 +49,10 @@ export function ScrollablePills({
     <Tabs value={value} onValueChange={onValueChange} className={cn("gap-0", className)}>
       <TabsList
         ref={listRef}
-        className={cn("justify-start overflow-x-auto scrollbar-hide flex-nowrap", maxWidth)}
+        className={cn(
+          "justify-start overflow-x-auto overflow-y-hidden scrollbar-hide flex-nowrap",
+          maxWidth,
+        )}
       >
         {items.map((item) => (
           <TabsTrigger key={item.id} value={item.id} className="shrink-0">

--- a/lib/client-migrations.ts
+++ b/lib/client-migrations.ts
@@ -1,0 +1,25 @@
+/**
+ * Client-side localStorage migrations that run before React hydration.
+ * Each entry has an expiry date — a test enforces removal after expiry.
+ *
+ * This is serialized into an inline <script> in layout.tsx — keep entries
+ * synchronous, dependency-free, and as small as possible.
+ */
+
+export interface ClientMigration {
+  id: string;
+  expiresAt: string; // ISO date (YYYY-MM-DD)
+  script: string;
+}
+
+export const CLIENT_MIGRATIONS: ClientMigration[] = [
+  {
+    id: "cherry-blossom-to-sakura",
+    expiresAt: "2026-08-20",
+    script: `if(localStorage.getItem("theme")==="cherry-blossom")localStorage.setItem("theme","sakura")`,
+  },
+];
+
+export function getClientMigrationScript(): string {
+  return CLIENT_MIGRATIONS.map((m) => m.script).join(";");
+}


### PR DESCRIPTION
- Session views: hide button labels on mobile, change devo icon to BookOpen
- Devotional view: facilitator toggle on its own line on mobile
- Root page: title/icons stack on mobile (icons above, title below)
- Rename cherry-blossom theme to sakura (internal + display)
- Migrate users from cherry-blossom to sakura with expiry-enforced test