### PR TITLE
feat: add changelog widget with auto-open and dedicated page

### DIFF
--- a/app/[sport]/layout.tsx
+++ b/app/[sport]/layout.tsx
@@ -2,9 +2,11 @@ import Image from "next/image";
 import Link from "next/link";
 import AuthButton from "@/components/sports/auth-button";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { ChangelogWidget } from "@/components/sports/changelog-widget";
 import LayoutHeader from "@/components/sports/layout-header";
 import { getResolvedSportConfig } from "@/lib/get-sport-config";
 import { getUser } from "@/lib/supabase/user";
+import { CHANGELOG } from "@/config/changelog";
 import { notFound } from "next/navigation";
 
 export default async function SportLayout({
@@ -31,6 +33,7 @@ export default async function SportLayout({
           NTCBC Signups
         </Link>
         <div className="flex items-center gap-2">
+          {user && <ChangelogWidget entries={CHANGELOG.slice(0, 10)} />}
           <ThemeToggle />
           {config.authEnabled && <AuthButton user={user} sport={sport} />}
         </div>

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import Image from "next/image";
+import { CHANGELOG } from "@/config/changelog";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+export default function ChangelogPage() {
+  return (
+    <div className="max-w-2xl mx-auto mb-12 space-y-8 pt-4">
+      <div className="flex items-center justify-between">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Image src="/favicon.ico" alt="NTCBC" width={18} height={18} className="rounded-sm" />
+          NTCBC Signups
+        </Link>
+        <ThemeToggle />
+      </div>
+
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">What&apos;s New</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Updates and improvements to NTCBC Signups.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {CHANGELOG.map((entry) => (
+          <article key={entry.id} className="border-l-2 border-border pl-4">
+            <time className="text-xs text-muted-foreground">
+              {new Date(entry.date).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <h2 className="text-base font-semibold mt-0.5">{entry.title}</h2>
+            <p className="text-sm text-muted-foreground mt-1">{entry.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,8 +6,10 @@ import { ArrowRight, CalendarDays, Clock, Users } from "lucide-react";
 import { getResolvedSportsConfigBySport } from "@/lib/get-sport-config";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { ChangelogWidget } from "@/components/sports/changelog-widget";
 import AuthButton from "@/components/sports/auth-button";
 import { getUser } from "@/lib/supabase/user";
+import { CHANGELOG } from "@/config/changelog";
 
 export default async function Home() {
   const dbSportsBySlug = await getResolvedSportsConfigBySport();
@@ -22,6 +24,7 @@ export default async function Home() {
           NTCBC Signups
         </h1>
         <div className="flex items-center gap-2 self-end sm:self-auto">
+          {user && <ChangelogWidget entries={CHANGELOG.slice(0, 10)} />}
           <ThemeToggle />
           <AuthButton user={user} />
         </div>

--- a/components/sports/changelog-widget.tsx
+++ b/components/sports/changelog-widget.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { Megaphone } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { ChangelogEntry } from "@/config/changelog";
+
+const STORAGE_KEY = "changelogSeen";
+
+function getSeenId(): number {
+  if (typeof window === "undefined") return 0;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? Number(raw) : 0;
+}
+
+function formatRelativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? "1mo ago" : `${months}mo ago`;
+}
+
+export function ChangelogWidget({ entries }: { entries: ChangelogEntry[] }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [seenId, setSeenId] = useState(0);
+  const [mounted, setMounted] = useState(false);
+  const [autoOpenedFor, setAutoOpenedFor] = useState<string | null>(null);
+
+  // Hydrate from localStorage after mount
+  useEffect(() => {
+    setSeenId(getSeenId());
+    setMounted(true);
+  }, []);
+
+  // Auto-open when there are unread entries relevant to the current page (once per navigation)
+  useEffect(() => {
+    if (!mounted || open || autoOpenedFor === pathname) return;
+    const hasRelevantUnread = entries.some(
+      (e) => e.id > seenId && (!e.routes || e.routes.some((r) => pathname.startsWith(r))),
+    );
+    if (!hasRelevantUnread) return;
+
+    const timer = setTimeout(() => {
+      setOpen(true);
+      setAutoOpenedFor(pathname);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [pathname, mounted, seenId, entries, open, autoOpenedFor]);
+
+  const latestId = entries[0]?.id ?? 0;
+  const unreadCount = entries.filter((e) => e.id > seenId).length;
+
+  // Auto-mark as read after popover is open for 1 second
+  useEffect(() => {
+    if (!open || seenId >= latestId) return;
+    const timer = setTimeout(() => {
+      localStorage.setItem(STORAGE_KEY, String(latestId));
+      setSeenId(latestId);
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [open, seenId, latestId]);
+
+  const markAllRead = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, String(latestId));
+    setSeenId(latestId);
+    setOpen(false);
+  }, [latestId]);
+
+  if (!mounted) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={`relative h-8 w-8 ${open ? "bg-accent text-accent-foreground" : ""}`}
+        >
+          <Megaphone className="h-4 w-4" />
+          {unreadCount > 0 && (
+            <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary" />
+          )}
+          <span className="sr-only">What&apos;s new</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" collisionPadding={12} sideOffset={8} className="w-80 p-0">
+        <PopoverArrow width={14} height={7} />
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h3 className="text-sm font-semibold">What&apos;s New</h3>
+          {unreadCount > 0 && (
+            <button
+              onClick={markAllRead}
+              className="text-xs text-primary hover:text-primary/80 font-medium cursor-pointer"
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+        <div className="max-h-72 overflow-y-auto overscroll-contain">
+          {entries.map((entry) => {
+            const isUnread = entry.id > seenId;
+            const isRelevant =
+              isUnread && (!entry.routes || entry.routes.some((r) => pathname.startsWith(r)));
+            return (
+              <div
+                key={entry.id}
+                className={`px-4 py-3 border-b last:border-b-0 ${
+                  isRelevant
+                    ? "border-l-2 border-l-primary bg-primary/5"
+                    : isUnread
+                      ? "border-l-2 border-l-primary/40"
+                      : ""
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{entry.title}</span>
+                  {isUnread && (
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-primary">
+                      New
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">{entry.description}</p>
+                <span className="text-[11px] text-muted-foreground/60 mt-1 block">
+                  {formatRelativeDate(entry.date)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="border-t px-4 py-2">
+          <Link
+            href="/changelog"
+            onClick={() => setOpen(false)}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            View all updates →
+          </Link>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -39,4 +39,17 @@ function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitiv
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+function PopoverArrow({
+  className,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Arrow>) {
+  return (
+    <PopoverPrimitive.Arrow
+      data-slot="popover-arrow"
+      className={cn("fill-popover stroke-border", className)}
+      {...props}
+    />
+  );
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor, PopoverArrow };

--- a/config/changelog.ts
+++ b/config/changelog.ts
@@ -1,0 +1,205 @@
+export interface ChangelogEntry {
+  /** Sequential integer — used as high water mark for read tracking. */
+  id: number;
+  /** ISO date string (YYYY-MM-DD) for display. */
+  date: string;
+  title: string;
+  description: string;
+  /** Optional route prefixes where the popover auto-opens for this entry. */
+  routes?: string[];
+}
+
+/**
+ * App changelog entries — newest first.
+ * To announce a new feature, prepend an entry with the next sequential `id`.
+ */
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    id: 27,
+    date: "2026-07-16",
+    title: "Sakura Theme",
+    description: "A beautiful new cherry blossom theme is available in the theme picker!",
+  },
+  {
+    id: 26,
+    date: "2026-07-13",
+    title: "New Home Page",
+    description:
+      "The home page has been redesigned with quick access to sign-in and theme switching!",
+  },
+  {
+    id: 25,
+    date: "2026-07-10",
+    title: "CCSA Game Sync",
+    description: "Admins can now sync game schedules directly from CCSA — no more manual entry!",
+    routes: ["/softball/admin"],
+  },
+  {
+    id: 24,
+    date: "2026-07-06",
+    title: "Quick Devotional Access",
+    description: "A shortcut button now lets you jump straight to the devotional from any session!",
+  },
+  {
+    id: 23,
+    date: "2026-07-06",
+    title: "Statistics",
+    description:
+      "View your personal signup history and attendance stats — admins also get signup trends, engagement metrics, and calendar usage!",
+  },
+  {
+    id: 22,
+    date: "2026-07-01",
+    title: "People Management",
+    description:
+      "Admins can now view and manage all members, roles, and team access from a dedicated People tab!",
+  },
+  {
+    id: 21,
+    date: "2026-07-01",
+    title: "Basketball Gets Sign-In",
+    description:
+      "Basketball has been upgraded from Google Sheets to the full app experience with Google sign-in!",
+    routes: ["/basketball"],
+  },
+  {
+    id: 20,
+    date: "2026-06-29",
+    title: "Volleyball Gets Sign-In",
+    description:
+      "Volleyball has been upgraded from Google Sheets to the full app experience with Google sign-in!",
+    routes: ["/volleyball"],
+  },
+  {
+    id: 19,
+    date: "2026-06-29",
+    title: "Clickable Links in Notes",
+    description: "URLs in session notes are now clickable — tap to open links directly!",
+  },
+  {
+    id: 18,
+    date: "2026-06-28",
+    title: "Session Facilitators",
+    description:
+      "Sessions can now have a designated facilitator — admins can assign someone to help run things!",
+  },
+  {
+    id: 17,
+    date: "2026-06-23",
+    title: "Devotionals",
+    description:
+      "Sessions can now include a devotional section for group reflection and discussion!",
+  },
+  {
+    id: 16,
+    date: "2026-06-05",
+    title: "Calendar Export",
+    description:
+      "Subscribe to your sport's schedule with a personal iCal feed — syncs right to Google Calendar, Apple Calendar, and more!",
+  },
+  {
+    id: 15,
+    date: "2026-06-04",
+    title: "Admin Settings Page",
+    description:
+      "Admins can now configure sport settings, tabs, and permissions right from the app — no code changes needed!",
+  },
+  {
+    id: 14,
+    date: "2026-06-01",
+    title: "Softball Socials",
+    description:
+      "Social events are now a session type for softball — sign up for hangouts and team bonding!",
+    routes: ["/softball"],
+  },
+  {
+    id: 13,
+    date: "2026-05-24",
+    title: "Waitlist Management",
+    description:
+      "Admins can now promote and demote signups directly from the attendance view — managing the waitlist is a breeze!",
+  },
+  {
+    id: 12,
+    date: "2026-05-22",
+    title: "Fielding View",
+    description:
+      "Softball admins can now set up fielding positions with a diamond layout and lineup tracking!",
+    routes: ["/softball"],
+  },
+  {
+    id: 11,
+    date: "2026-05-22",
+    title: "Session Views",
+    description:
+      "Admins can now set up custom session views like attendance tracking and ordered lineups!",
+  },
+  {
+    id: 10,
+    date: "2026-05-19",
+    title: "Edit & Cancel Sessions",
+    description: "Admins can now edit session details and cancel sessions directly from the app!",
+  },
+  {
+    id: 9,
+    date: "2026-05-19",
+    title: "Dark Mode",
+    description: "Toggle between light and dark themes from the contrast icon in the header!",
+  },
+  {
+    id: 8,
+    date: "2026-05-15",
+    title: "Session Filter",
+    description: "Filter sessions by type to quickly find practices, games, or umpiring!",
+  },
+  {
+    id: 7,
+    date: "2026-05-04",
+    title: "Session Types",
+    description:
+      "Sessions now have types like practices, games, and umpiring — so you always know what's coming up!",
+  },
+  {
+    id: 6,
+    date: "2026-05-04",
+    title: '"Unable to Join" Status',
+    description:
+      "You can now let organizers know you can't make it — a new response option besides signing up or cancelling!",
+  },
+  {
+    id: 5,
+    date: "2026-04-22",
+    title: "Team Member Badges",
+    description: "You can now see who's a registered team member right in the signup lists!",
+  },
+  {
+    id: 4,
+    date: "2026-04-21",
+    title: "CCSA Player Sync",
+    description: "Admins can now sync player data and waiver status directly from the CCSA system!",
+    routes: ["/softball/admin"],
+  },
+  {
+    id: 3,
+    date: "2026-03-28",
+    title: "Softball & Sign-In",
+    description:
+      "Softball is now on the app with Google sign-in for team management and roster tracking!",
+    routes: ["/softball"],
+  },
+  {
+    id: 2,
+    date: "2026-02-20",
+    title: "Basketball Added",
+    description: "Basketball now has its own signup page — check the schedule and sign up!",
+    routes: ["/basketball"],
+  },
+  {
+    id: 1,
+    date: "2025-06-28",
+    title: "NTCBC Signups is Live",
+    description:
+      "The app is here! Sign up for volleyball sessions with a countdown timer and player cap — no more group chat chaos!",
+    routes: ["/volleyball"],
+  },
+];


### PR DESCRIPTION
- Popover widget in header (signed-in users only) with unread dot badge
- Route-aware auto-open: shows relevant updates when navigating to matching pages
- High water mark localStorage tracking (single number, never grows)
- Auto-marks as read after 1s open; manual 'Mark all read' button
- Speech bubble arrow connecting popover to trigger icon
- Dedicated /changelog page with full history
- 27 curated user-facing changelog entries from git history
- PopoverArrow extracted to shared ui/popover component