### PR TITLE
refactor: remove anon signup option and authEnabled toggle

### DIFF
--- a/__tests__/fixtures/config.ts
+++ b/__tests__/fixtures/config.ts
@@ -47,7 +47,6 @@ export const BASE_CONFIG: SportConfig = {
 
 export const VALID_DB_ROW: SportConfigDbRow = {
   id: "volleyball",
-  auth_enabled: true,
   emoji: "🏐",
   name: "Volleyball",
   type: "volleyball",

--- a/app/[sport]/layout.tsx
+++ b/app/[sport]/layout.tsx
@@ -20,7 +20,7 @@ export default async function SportLayout({
   const config = await getResolvedSportConfig(sport);
   if (!config) notFound();
 
-  const user = config.authEnabled ? await getUser() : null;
+  const user = await getUser();
 
   return (
     <>
@@ -35,7 +35,7 @@ export default async function SportLayout({
         <div className="flex items-center gap-2">
           {user && <ChangelogWidget entries={CHANGELOG.slice(0, 10)} />}
           <ThemeToggle />
-          {config.authEnabled && <AuthButton user={user} sport={sport} />}
+          <AuthButton user={user} sport={sport} />
         </div>
       </LayoutHeader>
       {children}

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -354,7 +354,7 @@ export default async function SportAuthPage({
 
   // ── Auth ───────────────────────────────────────────────────────
   // Middleware validates the JWT and forwards the user via request header.
-  const user = config.authEnabled ? await getUser() : null;
+  const user = await getUser();
 
   return (
     <SportPageShell

--- a/components/sports/admin/admin-sidebar.tsx
+++ b/components/sports/admin/admin-sidebar.tsx
@@ -122,7 +122,7 @@ export default function AdminLayout({
       {/* Content area — show loading instantly on tab switch */}
       <div className="flex-1 min-w-0">
         {isPending && <LoadingAdminContent />}
-        <div className={isPending ? "hidden" : undefined}>{children}</div>
+        {!isPending && children}
       </div>
     </>
   );

--- a/components/sports/admin/admin-tabs/settings/dialogs.tsx
+++ b/components/sports/admin/admin-tabs/settings/dialogs.tsx
@@ -31,7 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { PillColor, Role } from "@/config/config-resolver";
+import { PillColor, AccessLevel, Role } from "@/config/config-resolver";
 import { SESSION_TAB_RULES } from "@/config/session-tab-rules";
 import { sessionPillClassFromColor } from "@/lib/session-type-pill";
 import { cn } from "@/lib/utils";
@@ -330,35 +330,50 @@ export function PermissionsDialog({
         </DialogHeader>
 
         <div className="space-y-3">
-          {ACCESS_LEVEL_OPTIONS.map((accessLevel) => (
-            <div key={`permission-${accessLevel.value}`} className="space-y-2">
-              <Label>{accessLevel.label}</Label>
-              <p className="text-xs text-muted-foreground">{accessLevel.description}</p>
-              <Select
-                value={String(permissionsDraft[accessLevel.value])}
-                onValueChange={(value) =>
-                  setPermissionsDraft((prev) => ({
-                    ...prev,
-                    [accessLevel.value]: Number(value) as Role,
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {ROLE_OPTIONS.map((roleOption) => (
-                    <SelectItem
-                      key={`${accessLevel.value}-${roleOption.value}`}
-                      value={String(roleOption.value)}
-                    >
-                      {roleOption.label} - {roleOption.description}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ))}
+          {ACCESS_LEVEL_OPTIONS.map((accessLevel) => {
+            const isSignup = accessLevel.value === AccessLevel.signup;
+            const roleOptions = isSignup
+              ? ROLE_OPTIONS.filter((o) => o.value !== Role.anon)
+              : ROLE_OPTIONS;
+            const selectedRole = permissionsDraft[accessLevel.value];
+            const showAnonHint = !isSignup && selectedRole === Role.anon;
+
+            return (
+              <div key={`permission-${accessLevel.value}`} className="space-y-2">
+                <Label>{accessLevel.label}</Label>
+                <p className="text-xs text-muted-foreground">{accessLevel.description}</p>
+                <Select
+                  value={String(selectedRole)}
+                  onValueChange={(value) =>
+                    setPermissionsDraft((prev) => ({
+                      ...prev,
+                      [accessLevel.value]: Number(value) as Role,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {roleOptions.map((roleOption) => (
+                      <SelectItem
+                        key={`${accessLevel.value}-${roleOption.value}`}
+                        value={String(roleOption.value)}
+                      >
+                        {roleOption.label} - {roleOption.description}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {showAnonHint && (
+                  <p className="text-xs text-muted-foreground">
+                    Users not signed in can only see static session content (e.g. devotionals). User
+                    data like signups and names will be hidden.
+                  </p>
+                )}
+              </div>
+            );
+          })}
         </div>
 
         <DialogFooter>

--- a/components/sports/admin/admin-tabs/settings/form-sections.tsx
+++ b/components/sports/admin/admin-tabs/settings/form-sections.tsx
@@ -45,17 +45,6 @@ export function GeneralSettingsSection({ state, setState }: GeneralSettingsSecti
 
   return (
     <CollapsibleSection title="General" description="Basic info and logistics for this sport.">
-      <div className="flex items-center gap-2 pt-4">
-        <input
-          id="auth-enabled"
-          type="checkbox"
-          checked={state.authEnabled}
-          onChange={(event) => setState((prev) => ({ ...prev, authEnabled: event.target.checked }))}
-          className="h-4 w-4 rounded border-input"
-        />
-        <Label htmlFor="auth-enabled">Enable Google Login</Label>
-      </div>
-
       <div className="grid gap-4 sm:grid-cols-2 pt-4 min-w-0">
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>

--- a/components/sports/admin/admin-tabs/settings/helpers.ts
+++ b/components/sports/admin/admin-tabs/settings/helpers.ts
@@ -93,7 +93,6 @@ export function buildInitialState(
 ): SportConfigFormState {
   return {
     id: sport,
-    authEnabled: config.authEnabled ?? false,
     emoji: config.emoji,
     name: config.name,
     type: config.type,

--- a/components/sports/admin/admin-tabs/settings/index.tsx
+++ b/components/sports/admin/admin-tabs/settings/index.tsx
@@ -295,7 +295,6 @@ function SportConfigFormInner({ sport }: { sport: string }) {
 
     const payload: UpdateSportConfigInput = {
       id: state.id,
-      authEnabled: state.authEnabled,
       emoji: state.emoji.trim(),
       name: state.name.trim(),
       type: state.type.trim(),

--- a/components/sports/admin/admin-tabs/settings/types.ts
+++ b/components/sports/admin/admin-tabs/settings/types.ts
@@ -37,7 +37,6 @@ export interface EditableAdminTab extends AdminTabMeta {
 
 export interface SportConfigFormState {
   id: string;
-  authEnabled: boolean;
   emoji: string;
   name: string;
   type: string;

--- a/config/config-interfaces.ts
+++ b/config/config-interfaces.ts
@@ -106,7 +106,6 @@ export interface SportConfig {
   tabs?: SessionTab[];
   defaultTab?: string;
   defaultAdminTab?: string;
-  authEnabled?: boolean;
   /** Extra sport-specific tabs to show in the admin sidebar. */
   adminTabs?: AdminTabMeta[];
 }
@@ -154,7 +153,6 @@ export interface SportConfigPayload {
  */
 export interface SportConfigDbRow {
   id: string;
-  auth_enabled: boolean;
   emoji: string;
   name: string;
   type: string;

--- a/config/config-resolver.ts
+++ b/config/config-resolver.ts
@@ -63,7 +63,6 @@ export function sportConfigFromDbRow(row: SportConfigDbRow): SportConfig | null 
 
   return {
     id: row.id,
-    authEnabled: row.auth_enabled,
     emoji: row.emoji,
     name: row.name,
     type: row.type,

--- a/lib/actions/sport-config.ts
+++ b/lib/actions/sport-config.ts
@@ -28,12 +28,17 @@ const tabSchema = z.object({
   label: z.string().min(1),
   defaultTitlePrefix: z.string().optional(),
   sessionPillColor: z.enum(PillColor),
-  permissions: z.object({
-    [AccessLevel.overview]: roleSchema,
-    [AccessLevel.view]: roleSchema,
-    [AccessLevel.signup]: roleSchema,
-    [AccessLevel.admin]: roleSchema,
-  }),
+  permissions: z
+    .object({
+      [AccessLevel.overview]: roleSchema,
+      [AccessLevel.view]: roleSchema,
+      [AccessLevel.signup]: roleSchema,
+      [AccessLevel.admin]: roleSchema,
+    })
+    .refine((p) => p[AccessLevel.signup] !== Role.anon, {
+      message: "Anonymous signup is not allowed",
+      path: [AccessLevel.signup],
+    }),
   signupConfirmationDialog: signupDialogSchema.optional(),
 });
 
@@ -46,7 +51,6 @@ const adminTabSchema = z.object({
 const updateSportConfigInputSchema = z
   .object({
     id: z.string().min(1),
-    authEnabled: z.boolean(),
     emoji: z.string().min(1),
     name: z.string().min(1),
     type: z.string().min(1),
@@ -206,7 +210,6 @@ export async function updateSportConfig(
   const { error } = await supabase
     .from("sport_configs")
     .update({
-      auth_enabled: parsed.data.authEnabled,
       emoji: parsed.data.emoji,
       name: parsed.data.name,
       type: parsed.data.type,

--- a/lib/get-data.ts
+++ b/lib/get-data.ts
@@ -321,7 +321,6 @@ function normalizeSportConfigPayload(payload: unknown): SportConfigPayload {
 
 function mapSportConfigRow(row: {
   id: string;
-  auth_enabled: boolean;
   emoji: string;
   name: string;
   type: string;
@@ -333,7 +332,6 @@ function mapSportConfigRow(row: {
 }): SportConfigDbRow {
   return {
     id: row.id,
-    auth_enabled: row.auth_enabled,
     emoji: row.emoji,
     name: row.name,
     type: row.type,
@@ -350,9 +348,7 @@ export async function getSportConfigRow(sport: string): Promise<SportConfigDbRow
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("sport_configs")
-    .select(
-      "id, auth_enabled, emoji, name, type, description, config, updated_by, updated_at, created_at",
-    )
+    .select("id, emoji, name, type, description, config, updated_by, updated_at, created_at")
     .eq("id", sport)
     .maybeSingle();
 
@@ -365,9 +361,7 @@ export async function getSportConfigRows(): Promise<SportConfigDbRow[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("sport_configs")
-    .select(
-      "id, auth_enabled, emoji, name, type, description, config, updated_by, updated_at, created_at",
-    )
+    .select("id, emoji, name, type, description, config, updated_by, updated_at, created_at")
     .order("created_at", { ascending: true });
 
   if (error || !data) return [];

--- a/supabase/migrations/20260725000000_remove_auth_enabled_column.sql
+++ b/supabase/migrations/20260725000000_remove_auth_enabled_column.sql
@@ -1,0 +1,4 @@
+-- Auth is now mandatory for all sports — remove the toggle column.
+-- Safety: set all existing rows to true before dropping, in case any downstream
+-- system still reads the column during the migration window.
+ALTER TABLE public.sport_configs DROP COLUMN auth_enabled;


### PR DESCRIPTION
- Add Zod refinement rejecting Role.anon for signup permissions
- Filter 'Anyone' from signup role dropdown in permissions dialog
- Add hint when overview/view is set to 'Anyone' (no user data visible)
- Remove 'Enable Google Login' toggle — auth is now mandatory
- Clean up authEnabled from types, config interfaces, resolver, form state
- Always call getUser() and render AuthButton unconditionally
- Remove auth_enabled from DB queries and SportConfigDbRow type
- Fix Recharts 0x0 warning by unmounting tab content during transitions
- Add migration to drop auth_enabled column