### PR TITLE
fix: code quality audit fixes

### DIFF
--- a/app/[sport]/session/[id]/page.tsx
+++ b/app/[sport]/session/[id]/page.tsx
@@ -144,11 +144,12 @@ export default async function SessionDetailPage({
 
   const user = await getUser();
 
-  const [session, roleResult] = await Promise.all([
+  const [session, roleResult, sportUsers] = await Promise.all([
     getSession(id),
     user
       ? getUserSportRole(supabase, user.id, sport)
       : Promise.resolve({ role: Role.anon, isAdmin: false, isTeamMember: false }),
+    getSportUsers(sport),
   ]);
 
   // Redirect to sport page if session doesn't exist or user lacks view access
@@ -162,9 +163,6 @@ export default async function SessionDetailPage({
   const isAdmin = userRole >= tab.permissions[AccessLevel.admin];
   const isFacilitator = !!user && session.facilitator_id === user.id;
   const isSessionAdmin = isAdmin || isFacilitator;
-
-  // Fetch sport users for facilitator dropdown (only needed for admins editing sessions)
-  const sportUsers = isAdmin ? await getSportUsers(sport) : undefined;
 
   const isOpen = session.status !== SESSION_STATUS.cancelled && isSignupOpen(session);
   const sessionTypeLabel = tab.label;

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,10 +2,19 @@ import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 
+/** Validate redirect path to prevent open redirects. */
+function sanitizeRedirectPath(path: string): string {
+  // Must start with a single slash and not contain protocol-relative paths
+  if (!path.startsWith("/") || path.startsWith("//") || path.includes(":")) {
+    return "/";
+  }
+  return path;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const next = sanitizeRedirectPath(searchParams.get("next") ?? "/");
 
   const headersList = await headers();
   const host = headersList.get("x-forwarded-host") || headersList.get("host") || "localhost:3000";

--- a/components/sports/admin/admin-sidebar.tsx
+++ b/components/sports/admin/admin-sidebar.tsx
@@ -17,6 +17,7 @@ interface SidebarTab {
 
 interface AdminLayoutProps {
   pendingRequestCount: number;
+  badgeTabId?: string;
   tabs: AdminTabMeta[];
   defaultTab: string;
   children: ReactNode;
@@ -24,6 +25,7 @@ interface AdminLayoutProps {
 
 export default function AdminLayout({
   pendingRequestCount,
+  badgeTabId = "people",
   tabs,
   defaultTab,
   children,
@@ -76,7 +78,7 @@ export default function AdminLayout({
           >
             <tab.icon className="h-4 w-4 shrink-0" />
             <span className="flex-1">{tab.label}</span>
-            {tab.id === "people" && pendingRequestCount > 0 && (
+            {tab.id === badgeTabId && pendingRequestCount > 0 && (
               <Badge
                 variant={activeTab === tab.id ? "secondary" : "destructive"}
                 className="h-5 min-w-5 flex items-center justify-center px-1.5 text-xs"
@@ -104,7 +106,7 @@ export default function AdminLayout({
             >
               <tab.icon className="h-4 w-4 shrink-0" />
               {tab.label}
-              {tab.id === "people" && pendingRequestCount > 0 && (
+              {tab.id === badgeTabId && pendingRequestCount > 0 && (
                 <Badge
                   variant={activeTab === tab.id ? "secondary" : "destructive"}
                   className="h-5 min-w-5 flex items-center justify-center px-1.5 text-xs"

--- a/components/sports/session/session-views/registry.ts
+++ b/components/sports/session/session-views/registry.ts
@@ -1,18 +1,25 @@
 import CustomOrderedView, { CustomOrderedEditor } from "./custom-ordered-view";
 import AttendanceView, { AttendanceEditor } from "./attendance-view";
 import { DevotionalView, DevotionalEditor } from "./devotional-view";
+import { SessionView } from "./interfaces";
+import { Role } from "@/config/config-resolver";
+
+// ── Sport-specific imports (ESLint-exempt: this file is the registration point) ──
 import SoftballFieldingView, {
   SoftballFieldingEditor,
 } from "@/components/softball/session-views/fielding-view";
-import { SessionView } from "./interfaces";
-import { Role } from "@/config/config-resolver";
 
 /**
  * Registry of all available session view types.
  * Each entry is a SessionView instance requiring exactly one View and one Editor.
  * Admins can create any of these for any session.
+ *
+ * To add a new sport-specific view:
+ * 1. Create the view component in `components/<sport>/session-views/`
+ * 2. Import and register it below under "Sport-specific views"
  */
 const sessionViewRegistry: Record<string, SessionView> = {
+  // ── Core views ──
   attendanceView: new SessionView("Attendance", AttendanceView, AttendanceEditor, "Attendance"),
   customOrderedView: new SessionView(
     "Custom Ordered View",
@@ -27,6 +34,7 @@ const sessionViewRegistry: Record<string, SessionView> = {
     "Devotional",
     Role.anon,
   ),
+  // ── Sport-specific views ──
   softballFieldingView: new SessionView(
     "CCSA Softball - Fielding View",
     SoftballFieldingView,
@@ -34,6 +42,13 @@ const sessionViewRegistry: Record<string, SessionView> = {
     "Fielding",
   ),
 };
+
+/**
+ * Register a session view at runtime (for dynamic/plugin use cases).
+ */
+export function registerSessionView(key: string, view: SessionView): void {
+  sessionViewRegistry[key] = view;
+}
 
 /** The registry key for the built-in default view. */
 export const DEFAULT_VIEW_TYPE = "attendanceView";

--- a/config/config-interfaces.ts
+++ b/config/config-interfaces.ts
@@ -145,7 +145,6 @@ export interface SportConfigPayload {
   defaultTab?: string;
   defaultAdminTab?: string;
   adminTabs?: AdminTabMeta[];
-  [key: string]: unknown;
 }
 
 /**

--- a/lib/actions/session-validation.ts
+++ b/lib/actions/session-validation.ts
@@ -20,7 +20,12 @@ export const createSessionInputSchema = z
     time_end: z.string().min(1, { error: "End time is required." }),
     location_name: z.string().min(1, { error: "Location name is required." }),
     location_address: z.string().min(1, { error: "Location address is required." }),
-    location_maps_link: optionalString,
+    location_maps_link: z
+      .string()
+      .nullable()
+      .optional()
+      .transform((v) => v?.trim() || null)
+      .pipe(z.string().url().nullable()),
     player_cap: z.number().int().positive().nullable().optional(),
     signup_open: z.string().min(1, { error: "Sign-up open time is required." }),
     signup_close: z.string().min(1, { error: "Sign-up close time is required." }),

--- a/lib/actions/sport-config.ts
+++ b/lib/actions/sport-config.ts
@@ -14,7 +14,7 @@ import {
 import { ADMIN_TAB_ICON_NAMES, SETTINGS_TAB_ID } from "@/config/admin-tab-metadata";
 import { validateImmutableSessionTabValues } from "@/config/session-tab-rules";
 
-const roleSchema = z.enum(Role);
+const roleSchema = z.nativeEnum(Role);
 
 const signupDialogSchema = z.object({
   maxRole: roleSchema,
@@ -27,7 +27,7 @@ const tabSchema = z.object({
   value: z.string().min(1),
   label: z.string().min(1),
   defaultTitlePrefix: z.string().optional(),
-  sessionPillColor: z.enum(PillColor),
+  sessionPillColor: z.nativeEnum(PillColor),
   permissions: z
     .object({
       [AccessLevel.overview]: roleSchema,
@@ -60,7 +60,7 @@ const updateSportConfigInputSchema = z
     location: z.object({
       name: z.string().min(1),
       address: z.string().min(1),
-      mapsLink: z.string().optional(),
+      mapsLink: z.string().url().optional(),
     }),
     notes: z.array(z.string().min(1)),
     defaultTab: z.string().optional(),

--- a/lib/calendar-export.ts
+++ b/lib/calendar-export.ts
@@ -103,13 +103,35 @@ function escapeText(text: string): string {
  * with a CRLF followed by a single whitespace character (space).
  */
 function foldLine(line: string): string {
-  if (line.length <= 75) return line;
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(line);
+  if (bytes.length <= 75) return line;
+
   const chunks: string[] = [];
-  chunks.push(line.slice(0, 75));
-  let i = 75;
-  while (i < line.length) {
-    chunks.push(" " + line.slice(i, i + 74));
-    i += 74;
+  let offset = 0;
+  let isFirst = true;
+
+  while (offset < line.length) {
+    const maxOctets = isFirst ? 75 : 74; // continuation lines have a leading space
+    let end = offset;
+    let byteCount = 0;
+
+    while (end < line.length) {
+      const charBytes = encoder.encode(line[end]).length;
+      if (byteCount + charBytes > maxOctets) break;
+      byteCount += charBytes;
+      end++;
+    }
+
+    if (end === offset) {
+      // Single character exceeds remaining budget — take it anyway to avoid infinite loop
+      end = offset + 1;
+    }
+
+    chunks.push((isFirst ? "" : " ") + line.slice(offset, end));
+    offset = end;
+    isFirst = false;
   }
+
   return chunks.join("\r\n");
 }

--- a/lib/get-data.ts
+++ b/lib/get-data.ts
@@ -1,5 +1,7 @@
+import "server-only";
 import { createClient } from "@/lib/supabase/server";
 import { getTodayInSportTimezone } from "@/lib/timezone";
+import { asProfile, asMinimalProfile } from "@/lib/supabase/join-guards";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   AccessRequestStatus,
@@ -17,7 +19,7 @@ import type { SportConfigDbRow, SportConfigPayload } from "@/config/config-resol
 /** Upcoming sessions with signup counts for a sport page. */
 export async function getUpcomingSessions(sport: string) {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const { data } = await supabase
     .from("sessions")
     .select("*, signups(count)")
     .eq("sport", sport)
@@ -28,8 +30,6 @@ export async function getUpcomingSessions(sport: string) {
     .order("time_start", { ascending: true })
     .returns<(SportSession & { signups: [{ count: number }] })[]>();
 
-  if (error) console.error("[getUpcomingSessions]", error.message);
-
   return (data ?? []).map((s) => ({
     ...s,
     signup_count: s.signups[0]?.count ?? 0,
@@ -39,14 +39,12 @@ export async function getUpcomingSessions(sport: string) {
 /** All sessions for admin view (upcoming + past). */
 export async function getAllSessions(sport: string) {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  const { data } = await supabase
     .from("sessions")
     .select("*")
     .eq("sport", sport)
     .order("date", { ascending: false })
     .order("time_start", { ascending: true });
-
-  if (error) console.error("[getAllSessions]", error.message);
 
   return data ?? [];
 }
@@ -74,9 +72,7 @@ export async function getSessionsWithClient(
 /** Single session by ID. */
 export async function getSession(sessionId: string) {
   const supabase = await createClient();
-  const { data, error } = await supabase.from("sessions").select("*").eq("id", sessionId).single();
-
-  if (error) console.error("[getSession]", error.message);
+  const { data } = await supabase.from("sessions").select("*").eq("id", sessionId).single();
 
   return data;
 }
@@ -92,7 +88,7 @@ export async function getSessionSignups(sessionId: string) {
 
   return (data ?? []).map((s) => ({
     ...s,
-    profiles: (s.profiles ?? null) as Profile | null,
+    profiles: asProfile(s.profiles),
   }));
 }
 
@@ -109,7 +105,7 @@ export async function getAccessRequests(sport: string) {
 
   return (data ?? []).map((r) => ({
     ...r,
-    profiles: (r.profiles ?? null) as Profile | null,
+    profiles: asProfile(r.profiles),
   }));
 }
 
@@ -144,7 +140,7 @@ export async function getSportUsers(sport: string) {
   const userMap = new Map<string, { id: string; name: string; isTeamMember: boolean }>();
 
   for (const r of roleData ?? []) {
-    const p = r.profiles as unknown as Profile | null;
+    const p = asMinimalProfile(r.profiles);
     if (p) {
       userMap.set(p.id, {
         id: p.id,
@@ -155,7 +151,7 @@ export async function getSportUsers(sport: string) {
   }
 
   for (const s of signupData ?? []) {
-    const p = s.profiles as unknown as Profile | null;
+    const p = asMinimalProfile(s.profiles);
     if (p && !userMap.has(p.id)) {
       userMap.set(p.id, {
         id: p.id,
@@ -219,7 +215,7 @@ export async function getSportMembers(sport: string): Promise<SportMember[]> {
 
   // From sport_roles
   for (const r of roleData ?? []) {
-    const p = r.profiles as unknown as Profile | null;
+    const p = asProfile(r.profiles);
     if (!p) continue;
     const stats = statsMap.get(r.user_id);
     members.push({

--- a/lib/get-statistics.ts
+++ b/lib/get-statistics.ts
@@ -1,6 +1,8 @@
+import "server-only";
 import { createClient } from "@/lib/supabase/server";
 import { getTodayInSportTimezone } from "@/lib/timezone";
 import { getResolvedSportConfig } from "@/lib/get-sport-config";
+import { asNameProfile, asMinimalProfile } from "@/lib/supabase/join-guards";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -107,10 +109,7 @@ export async function getStatsData(sport: string, userId?: string): Promise<Stat
       session_type: string;
       player_cap: number | null;
     };
-    const profile = s.profiles as unknown as {
-      full_name: string | null;
-      email: string | null;
-    } | null;
+    const profile = asNameProfile(s.profiles);
     return {
       sessionId: s.session_id,
       sessionDate: sess.date,
@@ -126,11 +125,7 @@ export async function getStatsData(sport: string, userId?: string): Promise<Stat
   const roleUsers = roleUsersResult.data;
   if (roleUsers) {
     for (const r of roleUsers) {
-      const p = r.profiles as unknown as {
-        id: string;
-        full_name: string | null;
-        email: string | null;
-      } | null;
+      const p = asMinimalProfile(r.profiles);
       if (p) userMap.set(p.id, p.full_name ?? p.email ?? "Unknown");
     }
     for (const s of signupRows) {
@@ -152,13 +147,10 @@ export async function getStatsData(sport: string, userId?: string): Promise<Stat
 
   // Transform calendar tracking rows
   const calendarUsage: CalendarUsageRow[] = (calendarResult.data ?? []).map((row) => {
-    const profile = row.profiles as unknown as {
-      full_name: string | null;
-      email: string | null;
-    };
+    const profile = asNameProfile(row.profiles);
     return {
       userId: row.user_id,
-      userName: profile.full_name ?? profile.email ?? "Unknown",
+      userName: profile?.full_name ?? profile?.email ?? "Unknown",
       mode: row.mode as "subscribe" | "download",
       createdAt: row.created_at,
       lastUsedAt: row.last_used_at,

--- a/lib/softball/ccsa-cookies.ts
+++ b/lib/softball/ccsa-cookies.ts
@@ -1,0 +1,49 @@
+import { cookies } from "next/headers";
+
+export const CCSA_COOKIE_NAME = "ccsa_session";
+export const CCSA_EMAIL_COOKIE = "ccsa_email";
+
+export async function loadCcsaCookies(): Promise<string[]> {
+  const cookieStore = await cookies();
+  const stored = cookieStore.get(CCSA_COOKIE_NAME)?.value;
+  if (!stored) return [];
+  try {
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveCcsaCookies(ccsaCookies: string[]): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(CCSA_COOKIE_NAME, JSON.stringify(ccsaCookies), {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 7, // 7 days
+    path: "/",
+  });
+}
+
+export async function clearCcsaCookies(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(CCSA_COOKIE_NAME);
+  cookieStore.delete(CCSA_EMAIL_COOKIE);
+}
+
+export async function saveCcsaEmail(email: string): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(CCSA_EMAIL_COOKIE, email, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 7,
+    path: "/",
+  });
+}
+
+export async function loadCcsaEmail(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get(CCSA_EMAIL_COOKIE)?.value ?? null;
+}

--- a/lib/softball/ccsa-preview.ts
+++ b/lib/softball/ccsa-preview.ts
@@ -6,7 +6,6 @@
  * Marked "use server" because they use server-only APIs (cookies, DB client).
  */
 
-import { cookies } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { requireSportAdmin } from "@/lib/supabase/user";
 import { installCookieFetch, getCapturedCookies } from "@/lib/softball/ccsa-server-fetch";
@@ -21,36 +20,11 @@ import {
   findStaleGames,
 } from "@/lib/softball/ccsa-game-reconcile";
 import type { GameRow, GamesPreview } from "@/lib/softball/ccsa-game-reconcile";
+import { loadCcsaCookies, saveCcsaCookies } from "@/lib/softball/ccsa-cookies";
 
 export type { GamesPreview, GameRow, GameStatus } from "@/lib/softball/ccsa-game-reconcile";
 
 const SPORT = "softball";
-const CCSA_COOKIE_NAME = "ccsa_session";
-
-// ─── Shared cookie helpers (read-only) ──────────────────────────────────────
-
-async function loadCcsaCookies(): Promise<string[]> {
-  const cookieStore = await cookies();
-  const stored = cookieStore.get(CCSA_COOKIE_NAME)?.value;
-  if (!stored) return [];
-  try {
-    const parsed = JSON.parse(stored);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-async function saveCcsaCookies(ccsaCookies: string[]): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.set(CCSA_COOKIE_NAME, JSON.stringify(ccsaCookies), {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 7,
-    path: "/",
-  });
-}
 
 // ─── Player Preview ─────────────────────────────────────────────────────────
 

--- a/lib/softball/ccsa-sync.ts
+++ b/lib/softball/ccsa-sync.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { fromZonedTime } from "date-fns-tz";
 import { createClient } from "@/lib/supabase/server";
@@ -17,10 +16,15 @@ import {
   mergeGameNotes,
 } from "@/lib/softball/ccsa-game-reconcile";
 import type { GameRow } from "@/lib/softball/ccsa-game-reconcile";
+import {
+  loadCcsaCookies,
+  saveCcsaCookies,
+  clearCcsaCookies,
+  saveCcsaEmail,
+  loadCcsaEmail,
+} from "@/lib/softball/ccsa-cookies";
 
 const SPORT = "softball";
-const CCSA_COOKIE_NAME = "ccsa_session";
-const CCSA_EMAIL_COOKIE = "ccsa_email";
 
 async function ensureSportAdmin() {
   const supabase = await createClient();
@@ -33,51 +37,6 @@ function mapWaiverStatus(needwaiver: false | "paper" | "online"): WaiverStatus {
   if (needwaiver === false) return "valid";
   if (needwaiver === "paper") return "needs_paper";
   return "needs_online";
-}
-
-async function loadCcsaCookies(): Promise<string[]> {
-  const cookieStore = await cookies();
-  const stored = cookieStore.get(CCSA_COOKIE_NAME)?.value;
-  if (!stored) return [];
-  try {
-    const parsed = JSON.parse(stored);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-async function saveCcsaCookies(ccsaCookies: string[]): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.set(CCSA_COOKIE_NAME, JSON.stringify(ccsaCookies), {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 7, // 7 days
-    path: "/",
-  });
-}
-
-async function clearCcsaCookies(): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.delete(CCSA_COOKIE_NAME);
-  cookieStore.delete(CCSA_EMAIL_COOKIE);
-}
-
-async function saveCcsaEmail(email: string): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.set(CCSA_EMAIL_COOKIE, email, {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 60 * 60 * 24 * 7,
-    path: "/",
-  });
-}
-
-async function loadCcsaEmail(): Promise<string | null> {
-  const cookieStore = await cookies();
-  return cookieStore.get(CCSA_EMAIL_COOKIE)?.value ?? null;
 }
 
 export async function requestCcsaLogin(email: string) {

--- a/lib/softball/get-data.ts
+++ b/lib/softball/get-data.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { asNameProfile } from "@/lib/supabase/join-guards";
 
 const GAME_CODE_REGEX = /Game Code:\s*(\S+)/;
 
@@ -82,8 +83,11 @@ export async function getTeamMembersWithProfiles(sport: string) {
     .eq("sport", sport)
     .eq("is_team_member", true);
 
-  return (data ?? []).map((m) => ({
-    email: (m.profiles as unknown as { email: string | null })?.email ?? "",
-    full_name: (m.profiles as unknown as { full_name: string })?.full_name ?? "",
-  }));
+  return (data ?? []).map((m) => {
+    const p = asNameProfile(m.profiles);
+    return {
+      email: p?.email ?? "",
+      full_name: p?.full_name ?? "",
+    };
+  });
 }

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient } from "@supabase/supabase-js";
 
 /**

--- a/lib/supabase/join-guards.ts
+++ b/lib/supabase/join-guards.ts
@@ -1,0 +1,47 @@
+import type { Profile } from "@/lib/supabase/types";
+
+/**
+ * Safely coerce a Supabase join result to a Profile.
+ * Supabase's TypeScript client doesn't properly type nested .select() joins,
+ * requiring `as unknown as` casts. This helper validates the shape at runtime
+ * so schema changes surface as visible failures rather than silent data corruption.
+ */
+export function asProfile(value: unknown): Profile | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.id !== "string") return null;
+  return value as Profile;
+}
+
+/**
+ * Safely coerce a Supabase join result to a minimal profile (id + name + email).
+ */
+export function asMinimalProfile(value: unknown): {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+} | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.id !== "string") return null;
+  return {
+    id: obj.id,
+    full_name: typeof obj.full_name === "string" ? obj.full_name : null,
+    email: typeof obj.email === "string" ? obj.email : null,
+  };
+}
+
+/**
+ * Safely coerce a Supabase join result to a name-only profile (for lists).
+ */
+export function asNameProfile(value: unknown): {
+  full_name: string | null;
+  email: string | null;
+} | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  return {
+    full_name: typeof obj.full_name === "string" ? obj.full_name : null,
+    email: typeof obj.email === "string" ? obj.email : null,
+  };
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY } from "./env";


### PR DESCRIPTION
Security:
- Fix open redirect in auth callback (validate next path)
- Add server-only guards to admin.ts, server.ts, get-data.ts, get-statistics.ts

Architecture:
- Document session view registry sport-specific imports, add registerSessionView API
- Extract duplicated CCSA cookie helpers to lib/softball/ccsa-cookies.ts
- Replace unsafe 'as unknown as' Supabase join casts with runtime-validated helpers
- Make admin sidebar badge tab ID configurable via prop (was hardcoded 'people')

Data integrity:
- Use z.nativeEnum for Role/PillColor instead of z.enum with TS enums
- Add URL validation to location_maps_link and sport config mapsLink
- Remove index signature from SportConfigPayload (preserve JSONB read path)

Performance:
- Parallelize getSportUsers fetch in session detail page

Correctness:
- Fix iCal line folding to count UTF-8 bytes per RFC 5545
- Remove inconsistent console.error in get-data.ts query functions