### PR TITLE
feat: waiver link on sport page, loading spinner alignment, migration cleanup

### DIFF
--- a/app/[sport]/admin/loading.tsx
+++ b/app/[sport]/admin/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingAdminContent } from "@/components/sports/loading-content";
+
+export default function Loading() {
+  return (
+    <div className="max-w-6xl mx-auto mb-12 space-y-6">
+      <LoadingAdminContent />
+    </div>
+  );
+}

--- a/app/[sport]/loading.tsx
+++ b/app/[sport]/loading.tsx
@@ -2,7 +2,7 @@ import { LoadingSportPage } from "@/components/sports/loading-content";
 
 export default function Loading() {
   return (
-    <div className="max-w-4xl mx-auto mb-12 space-y-6 px-4 sm:px-6 lg:px-8">
+    <div className="max-w-4xl mx-auto mb-12 space-y-6">
       <LoadingSportPage />
     </div>
   );

--- a/app/[sport]/page.tsx
+++ b/app/[sport]/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import { getUser, getUserSportRole, getCachedUserSportRole } from "@/lib/supabase/user";
 import SessionCard from "@/components/sports/session/session-card";
@@ -7,6 +9,12 @@ import SessionFilter from "@/components/sports/session/session-filter";
 import TeamAccessBanner from "@/components/sports/signup/team-access-banner";
 import SignInToSignupBanner from "@/components/sports/signup/sign-in-to-signup-banner";
 import SportPageShell from "@/components/sports/sport-page-shell";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import AdminButton from "@/components/sports/admin/admin-button";
 import CalendarExportButton from "@/components/sports/session/calendar-export-button";
 import MyStatsButton from "@/components/sports/session/my-stats-button";
@@ -377,6 +385,40 @@ export default async function SportAuthPage({
         ) : null
       }
     >
+      {config.notes && config.notes.length > 0 && (
+        <Accordion type="single" collapsible>
+          <AccordionItem
+            value="important-notes"
+            className="border-b! rounded-lg border bg-card px-4 overflow-hidden"
+          >
+            <AccordionTrigger className="font-semibold text-foreground hover:no-underline">
+              <span className="flex items-center gap-2">
+                <span>📌</span>
+                Important Notes
+              </span>
+            </AccordionTrigger>
+            <AccordionContent>
+              <ul className="space-y-2.5 text-muted-foreground">
+                {config.notes.map((note) => (
+                  <li key={note} className="flex items-start text-sm">
+                    <div className="w-1.5 h-1.5 bg-muted-foreground/40 rounded-full mr-3 mt-1.5 shrink-0"></div>
+                    <span>{note}</span>
+                  </li>
+                ))}
+              </ul>
+              {config.waiverLink && (
+                <Button asChild variant="outline" size="sm" className="mt-4">
+                  <a href={config.waiverLink} target="_blank" rel="noopener noreferrer">
+                    <ArrowUpRight className="h-4 w-4 shrink-0" />
+                    View the waiver
+                  </a>
+                </Button>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+
       <Suspense fallback={<LoadingContent />}>
         <SportSessionsContent
           config={config}
@@ -387,18 +429,6 @@ export default async function SportAuthPage({
           userId={user?.id ?? null}
         />
       </Suspense>
-
-      <div>
-        <h2 className="font-semibold text-foreground mb-2">Important Notes</h2>
-        <ul className="space-y-2.5 ml-4 text-muted-foreground">
-          {config.notes?.map((note) => (
-            <li key={note} className="flex items-start text-sm">
-              <div className="w-1.5 h-1.5 bg-muted-foreground/40 rounded-full mr-3 mt-1.5 shrink-0"></div>
-              <span>{note}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
     </SportPageShell>
   );
 }

--- a/components/sports/admin/admin-tabs/settings/form-sections.tsx
+++ b/components/sports/admin/admin-tabs/settings/form-sections.tsx
@@ -290,6 +290,9 @@ export function GeneralSettingsSection({
 interface SessionTabsSectionProps {
   state: SportConfigFormState;
   setState: Dispatch<SetStateAction<SportConfigFormState>>;
+  fieldErrors: FieldErrors;
+  touchedFields: ReadonlySet<SportConfigFieldName>;
+  onBlur: (field: SportConfigFieldName) => void;
   defaultTabValue: string;
   defaultTabOptions: DefaultTabOption[];
   openEditTabDialog: (tabKey: string) => void;
@@ -310,6 +313,9 @@ interface SessionTabsSectionProps {
 export function SessionTabsSection({
   state,
   setState,
+  fieldErrors,
+  touchedFields,
+  onBlur,
   defaultTabValue,
   defaultTabOptions,
   openEditTabDialog,
@@ -324,15 +330,36 @@ export function SessionTabsSection({
         title="Sports Page"
         description="Public-facing notes visible to players on the sport page."
       >
-        <div className="space-y-2">
-          <Label htmlFor="notes">Notes (one per line)</Label>
-          <Textarea
-            id="notes"
-            rows={4}
-            value={state.notesText}
-            onChange={(event) => setState((prev) => ({ ...prev, notesText: event.target.value }))}
-            placeholder="Add notes visible to players on the sport page..."
-          />
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes (one per line)</Label>
+            <Textarea
+              id="notes"
+              rows={4}
+              value={state.notesText}
+              onChange={(event) => setState((prev) => ({ ...prev, notesText: event.target.value }))}
+              placeholder="Add notes visible to players on the sport page..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="waiverLink">Waiver link</Label>
+            <Input
+              id="waiverLink"
+              type="url"
+              value={state.waiverLink}
+              className={validInputClass("waiverLink", fieldErrors, touchedFields)}
+              onChange={(event) =>
+                setState((prev) => ({ ...prev, waiverLink: event.target.value }))
+              }
+              onBlur={() => onBlur("waiverLink")}
+              placeholder="https://forms.gle/..."
+            />
+            <p className="text-xs text-muted-foreground">
+              Optional. When set, a &quot;View the waiver&quot; button appears under Important Notes
+              on the sport page.
+            </p>
+            <FieldError error={fieldErrors.waiverLink} />
+          </div>
         </div>
       </SettingsCard>
 

--- a/components/sports/admin/admin-tabs/settings/helpers.ts
+++ b/components/sports/admin/admin-tabs/settings/helpers.ts
@@ -105,6 +105,7 @@ export function buildInitialState(
     description: config.description ?? "",
     day: config.day,
     organizers: config.organizers,
+    waiverLink: config.waiverLink ?? "",
     locationName: config.location.name,
     locationAddress: config.location.address,
     locationMapsLink: config.location.mapsLink ?? "",

--- a/components/sports/admin/admin-tabs/settings/index.tsx
+++ b/components/sports/admin/admin-tabs/settings/index.tsx
@@ -201,6 +201,7 @@ function SportConfigFormInner({ sport }: { sport: string }) {
       type: state.type,
       day: state.day,
       organizers: state.organizers,
+      waiverLink: state.waiverLink,
       locationName: state.locationName,
       locationAddress: state.locationAddress,
       locationMapsLink: state.locationMapsLink,
@@ -359,6 +360,7 @@ function SportConfigFormInner({ sport }: { sport: string }) {
       description: state.description.trim() || undefined,
       day: state.day.trim(),
       organizers: state.organizers.trim(),
+      waiverLink: state.waiverLink.trim() || undefined,
       location: {
         name: state.locationName.trim(),
         address: state.locationAddress.trim(),
@@ -710,6 +712,9 @@ function SportConfigFormInner({ sport }: { sport: string }) {
       <SessionTabsSection
         state={state}
         setState={setState}
+        fieldErrors={fieldErrors}
+        touchedFields={touchedFields}
+        onBlur={handleBlur}
         defaultTabValue={defaultTabValue}
         defaultTabOptions={defaultTabOptions}
         openEditTabDialog={openEditTabDialog}

--- a/components/sports/admin/admin-tabs/settings/types.ts
+++ b/components/sports/admin/admin-tabs/settings/types.ts
@@ -43,6 +43,7 @@ export interface SportConfigFormState {
   description: string;
   day: string;
   organizers: string;
+  waiverLink: string;
   locationName: string;
   locationAddress: string;
   locationMapsLink: string;

--- a/lib/actions/sport-config-validation.ts
+++ b/lib/actions/sport-config-validation.ts
@@ -49,6 +49,7 @@ export const updateSportConfigInputSchema = z
     description: z.string().optional(),
     day: z.string().min(1),
     organizers: z.string().min(1),
+    waiverLink: z.string().url().optional(),
     location: z.object({
       name: z.string().min(1),
       address: z.string().min(1),
@@ -132,6 +133,7 @@ export const sportConfigFieldSchemas = {
   type: requiredString,
   day: requiredString,
   organizers: requiredString,
+  waiverLink: z.string().url().optional(),
   locationName: requiredString,
   locationAddress: requiredString,
   locationMapsLink: z.string().url().optional(),
@@ -146,6 +148,7 @@ const FIELD_LABELS: Record<SportConfigFieldName, string> = {
   type: "Sport type",
   day: "Schedule",
   organizers: "Organisers",
+  waiverLink: "Waiver link",
   locationName: "Venue name",
   locationAddress: "Address",
   locationMapsLink: "Maps link",

--- a/lib/actions/sport-config.ts
+++ b/lib/actions/sport-config.ts
@@ -80,6 +80,7 @@ export async function updateSportConfig(
     ...existingConfig,
     day: parsed.data.day,
     organizers: parsed.data.organizers,
+    waiverLink: parsed.data.waiverLink || undefined,
     location: {
       name: parsed.data.location.name,
       address: parsed.data.location.address,

--- a/lib/client-migrations.ts
+++ b/lib/client-migrations.ts
@@ -12,13 +12,7 @@ export interface ClientMigration {
   script: string;
 }
 
-export const CLIENT_MIGRATIONS: ClientMigration[] = [
-  {
-    id: "cherry-blossom-to-sakura",
-    expiresAt: "2026-08-20",
-    script: `if(localStorage.getItem("theme")==="cherry-blossom")localStorage.setItem("theme","sakura")`,
-  },
-];
+export const CLIENT_MIGRATIONS: ClientMigration[] = [];
 
 export function getClientMigrationScript(): string {
   return CLIENT_MIGRATIONS.map((m) => m.script).join(";");


### PR DESCRIPTION
Three commits.

## `fix: align loading spinners with page header`

`app/[sport]/loading.tsx` carried `px-4 sm:px-6 lg:px-8` while `SportPageShell` has no horizontal padding, so the loading state sat indented relative to the header logo.

The admin route had **no `loading.tsx` of its own** and fell back to the sport one — which is `max-w-4xl` while the admin header is `max-w-6xl` (`layout-header.tsx` switches on pathname). Centred, those have different left edges, so admin was doubly misaligned. Added a dedicated `app/[sport]/admin/loading.tsx`.

## `feat: surface waiver link on sport page, editable by admins`

**Important Notes** moves above the session-type filter pills and becomes a collapsible accordion (collapsed by default so it doesn't push sessions down), prefixed with 📌. Empty `notes` no longer render a bare heading.

**No DB migration needed.** `waiverLink` already existed on `SportConfig` / `SportConfigPayload` and was already mapped through `config-resolver.ts` — and both basketball and volleyball already had values stored in `sport_configs.config`. Nothing read or wrote it. It lives in the JSONB `config` column, per the pattern the original migration sets out ("keep obvious global metadata in first-class columns and everything else in JSONB").

Added:
- admin field in the **Sports Page** settings card, directly under the Notes textarea it renders beneath, following the existing optional-URL pattern from `locationMapsLink`
- a `View the waiver` button at the bottom of the notes, shown only when a link is set, with `ArrowUpRight` on the left and `target="_blank" rel="noopener noreferrer"`

`SessionTabsSection` now receives `fieldErrors` / `touchedFields` / `onBlur` so the new field gets the same inline URL validation as every other URL field. Without it, save-time validation would flag the field with no message rendered anywhere.

## `chore: remove expired cherry-blossom-to-sakura client migration`

Shipped with #114 on 2026-07-20 alongside the theme rename, with a 30-day window for users to load the app once and have their stored theme rewritten. It expired 2026-08-20 and `client-migrations.test.ts` had been failing since — which is precisely what that test exists to do.

Anyone who hasn't opened the app since the rename keeps `theme: "cherry-blossom"` in localStorage; since that isn't in the themes list they fall back to the system theme, and re-picking sakura fixes it permanently. The migration infrastructure stays for the next one.

## Verification

Full pre-push suite passes — `format:check`, `lint`, `typecheck`, `knip`, and `test` (**339/339**). Pushed with the hook running, no bypass.

Not visually verified — the alignment fix and button styling are reasoned from the CSS, not rendered. The `max-w-4xl` vs `max-w-6xl` difference only shows above ~1152px.